### PR TITLE
Extremely basic menu implementation

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -3,3 +3,15 @@ languageCode = "en-us"
 defaultContentLanguage = "en"
 title = "Balance Glam"
 theme = "glam"
+
+[menu]
+  [[menu.main]]
+    identifier = 'home'
+    name = 'home'
+    url = '/'
+    weight = -1
+  [[menu.main]]
+    identifier = 'about'
+    name = 'about'
+    url = '/about/'
+    weight = 100

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,0 +1,6 @@
+<nav>
+  {{ $currentPage := . }}
+  {{ range .Site.Menus.main }}
+    <a href="{{ .URL }}" title="{{ .Title }}">{{ .Name }}</a>
+  {{ end }}
+</nav>


### PR DESCRIPTION
Fixes #5 and #4

Appearance changes slightly:
<img width="426" alt="Screen Shot 2021-08-27 at 1 15 44 PM" src="https://user-images.githubusercontent.com/83298827/131171428-1b943bd6-822d-42c0-8012-d6df3b79acb2.png">

And here's the changes to the exampleSite's `config.toml` to make this work:

```toml
[menu]
  [[menu.main]]
    identifier = 'home'
    name = 'home'
    url = '/'
    weight = -1
  [[menu.main]]
    identifier = 'about'
    name = 'about'
    url = '/about/'
    weight = 100
```