### PR TITLE
Author box breakout; changes to example frontmatter to show authors

### DIFF
--- a/exampleSite/content/jobs/healers/scholar/leveling-guide.md
+++ b/exampleSite/content/jobs/healers/scholar/leveling-guide.md
@@ -1,6 +1,9 @@
 ---
 lastmod: '2021-09-08'
 patch: 5.3
+authors:
+  - nonowazu
+  - johndoe
 changelog:
   - date: '2021-09-09'
     message: Made it lorem ipsum

--- a/layouts/partials/components/author_box.html
+++ b/layouts/partials/components/author_box.html
@@ -1,0 +1,5 @@
+<div>
+  <div class="mx-auto rounded-full bg-black bg-contain p-2 bg-origin-content bg-no-repeat" style="width: 90px; height: 90px; background-image: url(/theme-assets/jobs/scholar.svg)"></div>
+  <div class="text-center">{{ .name }}</div>
+  <div class="text-center">{{ .socials.discord_id }}</div>
+</div>

--- a/layouts/partials/components/guide_meta_slider.html
+++ b/layouts/partials/components/guide_meta_slider.html
@@ -27,12 +27,7 @@
                             <div class="font-bold pb-4">AUTHORS</div>
                             <div class="flex flex-row gap-12">
                                 {{ range $author := $.Page.Params.authors }}
-                                    {{ $authorData := index $.Site.Data.author $author }}
-                                    <div>
-                                        <div class="mx-auto rounded-full bg-black bg-contain p-2 bg-origin-content bg-no-repeat" style="width: 90px; height: 90px; background-image: url(/theme-assets/jobs/scholar.svg)"></div>
-                                        <div class="text-center">{{ $authorData.name }}</div>
-                                        <div class="text-center">{{ $authorData.socials.discord_id }}</div>
-                                    </div>
+                                    {{ partial "components/author_box.html" (index $.Site.Data.author $author) }}
                                 {{ end }}
                             </div>
                         </div>


### PR DESCRIPTION
I honestly thought this was going to be worse. A TODO: for this would  be reflecting authors in the editor. I suggest using a [relation](https://www.netlifycms.org/docs/widgets/#relation) widget after you get an author collection going.