### PR TITLE
This one fix for your screenshot workflow may surprise you

### DIFF
--- a/.github/workflows/pr-creation.yml
+++ b/.github/workflows/pr-creation.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install dependencies
         run: |
           yarn
-          npm install -g postcss-cli autoprefixer postcss tailwindcss
+          npm install -g postcss-cli@8.3.1 autoprefixer postcss tailwindcss
       - name: Run Hugo
         run: hugo server -s exampleSite/ --themesDir=../.. --disableFastRender &
 


### PR DESCRIPTION
It's because the postcss-cli package apparently has a not great bug. So, we either update the entire node version in the workflow (perhaps consider this?) or just update one version.