### PR TITLE
fix shadows and some heading stylings

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -57,8 +57,27 @@ Content
   Jobs List
 */
 
+.role-header,
+.role-header-healer,
+.role-header-tank,
+.role-header-dps {
+	@apply font-bold text-white text-4xl filter uppercase font-head tracking-wider;
+}
+
 .role-header {
-	@apply font-bold text-white text-4xl filter drop-shadow-lg uppercase;
+	@apply drop-shadow-lg;
+}
+
+.role-header-healer {
+    @apply drop-shadow-lg-healer;
+}
+
+.role-header-tank {
+    @apply drop-shadow-lg-tank;
+}
+
+.role-header-dps {
+    @apply drop-shadow-lg-dps;
 }
 
 /*
@@ -120,7 +139,7 @@ It unfortunately also means we're limited to 5 tabs at current.
 */
 
 .card-title {
-    @apply font-bold text-white text-lg uppercase tracking-widest;
+    @apply font-bold text-white text-lg uppercase tracking-widest font-head;
 }
 
 .card-content {
@@ -255,7 +274,7 @@ Markdown - Can be used to auto apply styling to tags within the .markdown class
 }
 
 .markdown h3 {
-    @apply text-xl font-bold text-white uppercase tracking-widest mb-6;
+    @apply text-xl font-bold text-white uppercase tracking-widest mb-6 font-head;
 }
 
 .markdown p,

--- a/layouts/jobs/single.html
+++ b/layouts/jobs/single.html
@@ -13,7 +13,7 @@
         </div>
       </div>
       <div class="col-span-3 bg-card-light text-white divide-y divide-page px-5 sticky top-8">
-        <div class="card-title py-5">Table of Contents</div>
+        <div class="card-title pt-6 pb-5">Table of Contents</div>
         <div class="nested-link font-bold py-2">{{ .TableOfContents }}</div>
         <div>&nbsp;</div>
       </div>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -3,7 +3,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Kumbh+Sans:wght@700&family=Roboto:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
 
 {{ $styles := resources.Get "css/main.css" | postCSS }}
 {{ $headerJs := resources.Get "js/header.js" }}

--- a/layouts/partials/job/fundamentals.html
+++ b/layouts/partials/job/fundamentals.html
@@ -3,7 +3,7 @@
 <div class="container mx-auto">
   <section class="grid xl:grid-cols-12 gap-6 xl:gap-8">
     <div class="xl:col-span-6 xl:row-start-1 xl:row-span-2">
-      <h1 class="role-header mb-6">Job Fundamentals</h1>
+      <h1 class="role-header-{{ $role }} mb-6">Job Fundamentals</h1>
       {{ partial "cards/default.html" (dict "text" .Content "role" $role) }}
     </div>
 

--- a/layouts/partials/job/header.html
+++ b/layouts/partials/job/header.html
@@ -1,8 +1,10 @@
+{{ $role := .Page.Parent.Params.role }}
+
 <div class="h-60 xl:h-80">
   <div class="container mx-auto z-10 relative flex items-center h-full">
     <div class="flex items-center">
-      <img class="job-icon-lg mr-16 filter drop-shadow-lg" src="/theme-assets/jobs/{{ (lower .Title) }}.svg" />
-      <h1 class="text-6xl font-semibold filter drop-shadow-lg">{{ .Title }}</h1>
+      <img class="job-icon-lg mr-16 filter drop-shadow-lg-{{ $role }}" src="/theme-assets/jobs/{{ (lower .Title) }}.svg" />
+      <h1 class="text-6xl font-semibold filter drop-shadow-lg-{{ $role }}">{{ .Title }}</h1>
     </div>
   </div>
   <div class="bg-gray-600 absolute top-0 left-0 w-full -z-1" style="height: 460px;">

--- a/layouts/partials/job/single_header.html
+++ b/layouts/partials/job/single_header.html
@@ -1,21 +1,23 @@
+{{ $role := .Page.Parent.Parent.Params.role }}
+
 <div class="h-60 xl:h-80" style='background-image: url(/theme-assets/jobs/{{ lower .Parent.Title }}_background.png);'>
   <div class="container mx-auto z-10 relative flex items-center h-full">
     <div class="grid grid-cols-12 gap-8 w-full items-center">
         <div class="col-span-9 text-white">
-          <div class="flex items-center">
-            <img class="job-icon-sm mr-4 filter drop-shadow-lg" src='{{ print "/theme-assets/jobs/" (lower .Parent.Title) ".svg" }}' />
-            <div class="font-bold uppercase tracking-widest filter drop-shadow-lg"> {{ .Parent.Title }} </div> 
+          <div class="flex items-center mb-7">
+            <img class="job-icon-sm mr-4 filter drop-shadow-lg-{{ $role }}" src='{{ print "/theme-assets/jobs/" (lower .Parent.Title) ".svg" }}' />
+            <div class="card-title filter drop-shadow-lg-{{ $role }}"> {{ .Parent.Title }} </div> 
           </div>
           <div>
-            <div class="flex items-center">
-              <img class="inline mr-8 filter drop-shadow-lg" src="/theme-assets/book.svg" />
-              <div class="font-bold filter drop-shadow-lg" style="font-size: 60px;">{{ .Title }}</div>
+            <div class="flex items-center mb-3">
+              <img class="inline mr-8 filter drop-shadow-lg-{{ $role }}" src="/theme-assets/book.svg" />
+              <div class="font-bold filter drop-shadow-lg-{{ $role }} text-6xl">{{ .Title }}</div>
             </div>
-            <div style="font-size: 15px;">{{ .Param "description" }}</div>
+            <div class="filter drop-shadow-lg-{{ $role }}">{{ .Param "description" }}</div>
           </div>
         </div>
         <div class="col-span-3 bg-card-light text-white divide-y divide-page px-5">
-            <div class="card-title py-5">Guide Info</div>
+            <div class="card-title pt-5 pb-4">Guide Info</div>
             <div class="py-3 space-y-2 text-gray-light font-bold">
                 <div>Last Updated: {{ (time.Format "2 Jan, 2006" .Params.lastmod) }}</div>
                 <div>Patch Applicable: {{ .Param "patch" }}</div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,9 +6,14 @@ module.exports = {
   theme: {
     fontFamily: {
       'sans': ['Roboto', 'sans-serif'],
+      'head': ['Kumbh Sans', 'sans-serif']
     },
     extend: {
       dropShadow: {
+        'lg': '2px 2px 3px #000000',
+        'lg-healer': '2px 2px 3px #256A1D',
+        'lg-tank': '2px 2px 3px #1D3D6A',
+        'lg-dps': '2px 2px 3px #6A1D1D',
         '3xl': '0 100px 100px rgba(0, 0, 0, 0.75)',
       },
       colors: {
@@ -29,9 +34,6 @@ module.exports = {
       },
       zIndex: {
           '-1': '-1',
-      },
-      dropShadow: {
-          'lg': '2px 2px 5px rgba(0, 0, 0, 0.5)'
       },
       fontSize: {
         'base': '0.9375rem',
@@ -64,7 +66,7 @@ module.exports = {
                 ...acc,
                 ...variants.reduce((a, variant) => ({
                     ...a,
-                    [`.overlay-${e(key)}-${variant}`]: {
+                    [`.card-${e(key)}-${variant}`]: {
                         '--tw-border-color': colors[key][variant],
                     },
                 }), {}),


### PR DESCRIPTION
This is what I previously prepared in https://github.com/The-Balance-FFXIV/glam/pull/71 but now put into a seperate PR to both have smaller chunks of changes and not interrupt the review process. In theory this is not critical for soft launch but since I already finished it, I would appreciate adding this anyway.

## Extended `.role-header-[role]` class
- I noticed that we use different shadows depending on the selected role. To relfect that in addition to the `.role-header` class (for normal, black shadow) we also have a `.role-header-[role]` class for each of our 3 roles.
- To achieve that we also have now one dropShadow class for each role `.drop-shadow-lg-[role]`

## Misc
- Added "Kumbh Sans" font and made it available over the `.font-head` class
- Updated some margins and paddings