### PR TITLE
Hide savage and ultimate encounters on homepage

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -6,8 +6,8 @@
   {{/*  {{ partial "homepage/recents.html" . }}  */}}
 </div>
   {{ partial "homepage/join.html" . }}
-<div class="container mx-auto">
-  {{ partial "homepage/encounters.html" . }}
-</div>
+<!--div class="container mx-auto">
+{{/*  {{ partial "homepage/encounters.html" . }}  */}}
+</div-->
 {{/*  {{ partial "homepage/spotlight.html" . }}  */}}
 {{ end }}


### PR DESCRIPTION
Resolves #85 

Added underscore to encounter key in json to hide guides. This should make reverting this change easier.

Example of home page with this change:
![image](https://user-images.githubusercontent.com/65615038/141138026-500c5ea1-6af5-4d52-8f2f-8902a26530fd.png)
