### PR TITLE
Comment out role resources in job pages

### DIFF
--- a/layouts/jobs/bis.html
+++ b/layouts/jobs/bis.html
@@ -1,7 +1,6 @@
 {{ define "main" }}
 
 {{ $role := .Page.Parent.Page.Parent.Params.role }}
-{{ $job := .Params.job_name }}
 
 <div class="space-y-16">
   {{ $header := dict
@@ -40,7 +39,7 @@
     {{ partial "job/job_resources.html" .Parent }}
   </div>
 
-  {{ partial "job/role_resources.html" .Parent }}
+  {{/* {{ partial "job/role_resources.html" .Parent }} */}}
 
 </div>
 {{ end }}

--- a/layouts/jobs/changes.html
+++ b/layouts/jobs/changes.html
@@ -39,7 +39,7 @@
     {{ partial "job/job_resources.html" .Parent }}
   </div>
 
-  {{ partial "job/role_resources.html" .Parent }}
+  {{/* {{ partial "job/role_resources.html" .Parent }} */}}
 
 </div>
 {{ end }}

--- a/layouts/jobs/list.html
+++ b/layouts/jobs/list.html
@@ -10,7 +10,7 @@
   {{ partial "job/advanced_guides.html" . }}
 
   <div class="py-14 bg-no-repeat bg-cover" style="background-image: url('/theme-assets/jobs/{{ lower $role }}/{{ lower $role }}_resources_background.png');">
-    {{ partial "job/role_resources.html" . }}
+    {{/* {{ partial "job/role_resources.html" .Parent }} */}}
   </div>
 </div>
 {{ end }}

--- a/layouts/jobs/qna.html
+++ b/layouts/jobs/qna.html
@@ -39,7 +39,7 @@
     {{ partial "job/job_resources.html" .Parent }}
   </div>
 
-  {{ partial "job/role_resources.html" .Parent }}
+  {{/* {{ partial "job/role_resources.html" .Parent }} */}}
   
 </div>
 {{ end }}

--- a/layouts/jobs/single.html
+++ b/layouts/jobs/single.html
@@ -37,7 +37,7 @@
     {{ partial "job/job_resources.html" .Parent }}
   </div>
 
-  {{ partial "job/role_resources.html" .Parent }}
+  {{/* {{ partial "job/role_resources.html" .Parent }} */}}
 
 </div>
 {{ end }}


### PR DESCRIPTION
Resolves #97 
- hide role resources because nono said no
- Removed it from other pages as well, as it wouldn't make sense to keep them anywhere but the job landing page