### PR TITLE
Changed "Guide Meta" to "Authors"

### DIFF
--- a/layouts/partials/components/guide_meta_slider.html
+++ b/layouts/partials/components/guide_meta_slider.html
@@ -1,5 +1,5 @@
 <div class="tabbed">
-  {{ $metaCategories := slice "Guide Meta" "Contributors" "Changelog"}}
+  {{ $metaCategories := slice "Authors" "Contributors" "Changelog"}}
   {{ range $index, $role := $metaCategories }}
     <input type="radio" id="tab-{{ $role }}" name="css-tabs" {{ if eq $index 0 }}checked{{ end }}>
   {{ end }}
@@ -13,7 +13,7 @@
   {{ range $role := $metaCategories }}
     <div class="tab-content">
       {{/* This implementation is probably less than ideal right now */}}
-      {{ if eq . "Guide Meta" }}
+      {{ if eq . "Authors" }}
         <div class="card-title mb-5">Have any questions?</div>
         <div class="flex items-center mb-9">
           <img class="mr-4" src="/theme-assets/the_balance.png">


### PR DESCRIPTION
This just changes the "Guide Meta" tab to say "Authors". See, I'm still useful.
<img width="479" alt="Screen Shot 2021-11-12 at 3 21 05 PM" src="https://user-images.githubusercontent.com/83298827/141535973-547dbd67-d77a-4592-9df4-f7da35620e06.png">
