### PR TITLE
Header styling adjustments

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -318,15 +318,21 @@ Markdown - Can be used to auto apply styling to tags within the .markdown class
 }
 
 .markdown h2 {
-    @apply text-3xl font-bold text-white flex items-center;
+    @apply text-2xl font-bold text-white flex items-center uppercase;
+	letter-spacing: 2px;
 }
 
 .markdown h3 {
-    @apply text-xl font-bold text-white uppercase tracking-widest mb-6 font-head;
+    @apply text-xl font-bold text-white uppercase font-head;
+	letter-spacing: 2.25px;
 }
 
 .markdown p, h1, h2, h3, ol {
     @apply mb-8;
+}
+
+.markdown h1:not(:first-child) {
+	@apply mt-11;
 }
 
 .markdown ol {

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -309,15 +309,7 @@ Markdown - Can be used to auto apply styling to tags within the .markdown class
     @apply text-4xl font-bold text-white flex items-center;
 }
 
-.markdown h2 {
-    @apply text-3xl font-bold text-white flex items-center;
-}
-
-.markdown h2:not(:first-child) {
-    @apply mt-11;
-}
-
-.markdown h2:after {
+.markdown h1:after {
     @apply bg-page ml-5;
     flex: 1 0 0%;
     content: '';
@@ -325,13 +317,15 @@ Markdown - Can be used to auto apply styling to tags within the .markdown class
     height: 1px;
 }
 
+.markdown h2 {
+    @apply text-3xl font-bold text-white flex items-center;
+}
+
 .markdown h3 {
     @apply text-xl font-bold text-white uppercase tracking-widest mb-6 font-head;
 }
 
-.markdown p,
-.markdown h2,
-.markdown ol {
+.markdown p, h1, h2, h3, ol {
     @apply mb-8;
 }
 

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -43,7 +43,7 @@ theme = "glam"
 
 [markup]
   [markup.tableOfContents]
-    endLevel = 3
+    endLevel = 2
     startLevel = 1
 
 [params]


### PR DESCRIPTION
Supersedes #149 

* Moves the divider line to H1 tags to match mockups
* Adjusts capitalization and letter spacing of H2 and H3 tags to match mockups
* Adds bottom margins to H1 tags
* Adjusts the ToC config to only display H1 and H2 tags to avoid massive ToC lists

![image](https://user-images.githubusercontent.com/65056303/141922348-04388ff1-eaf4-42c7-9a51-c2654bda29e7.png)

