### PR TITLE
Fixed an issue with job name links in the sections header

### DIFF
--- a/layouts/jobs/bis.html
+++ b/layouts/jobs/bis.html
@@ -11,6 +11,7 @@
     "icon" "/theme-assets/armoury.svg"
     "lastmod" .Params.lastmod
     "patch" .Params.patch
+    "pageContext" .
   }}
   {{ partial "job/single_header.html" $header }}
 

--- a/layouts/jobs/changes.html
+++ b/layouts/jobs/changes.html
@@ -11,6 +11,7 @@
     "icon" "/theme-assets/news.svg"
     "lastmod" .Params.lastmod
     "patch" .Params.patch
+    "pageContext" .
   }}
   {{ partial "job/single_header.html" $header }}
 

--- a/layouts/jobs/qna.html
+++ b/layouts/jobs/qna.html
@@ -11,6 +11,7 @@
     "icon" "/theme-assets/question_bubble.svg"
     "lastmod" .Params.lastmod
     "patch" .Params.patch
+    "pageContext" .
   }}
   {{ partial "job/single_header.html" $header }}
 

--- a/layouts/jobs/single.html
+++ b/layouts/jobs/single.html
@@ -12,6 +12,7 @@
     "description" .Params.description
     "lastmod" .Params.lastmod
     "patch" .Params.patch
+    "pageContext" .
   }}
   {{ partial "job/single_header.html" $header }}
 

--- a/layouts/partials/job/single_header.html
+++ b/layouts/partials/job/single_header.html
@@ -3,7 +3,7 @@
     <div class="grid grid-cols-12 lg:gap-8 w-full items-center mt-8 lg:mt-0">
         <div class="col-span-12 lg:col-span-9 text-white responsive-container">
           <div class="flex items-center mb-7">
-            <a href="/jobs/{{ lower .role }}/{{ lower .jobTitle }}/" class="flex flex-row items-center" >
+            <a href="{{ .pageContext.Parent.Permalink }}" class="flex flex-row items-center" >
               <img class="job-icon-sm mr-4 filter drop-shadow-lg-{{ .role }}" src='{{ print "/theme-assets/jobs/" (lower .role) "/" (lower .job) "/" (lower .job) ".svg" }}' />
               <div class="card-title filter drop-shadow-lg-{{ .role }}">{{ .jobTitle }}</div> 
             </a>


### PR DESCRIPTION
Fixes #175 by using a context reference instead of trying to rebuild the name manually.