### PR TITLE
feat: made dropdown partial & added it to second navbar

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -58,7 +58,12 @@ header nav {
 }
 
 ul.nav-item li ul.nav-dropdown{
-	@apply invisible opacity-0 absolute transition-all delay-75 mt-1 left-0 hidden;
+	@apply invisible opacity-0 absolute transition-all delay-75 left-0 mt-1 hidden;
+}
+
+div.right-dropdown ul.nav-item li ul.nav-dropdown{
+	right: 0;
+	left: auto !important;
 }
 
 ul.nav-item li:hover > ul.nav-dropdown,

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -15,15 +15,9 @@
         </div>
       </div>
       <!-- Navbar items -->
-      <div class="hidden lg:flex items-center space-x-3 ">
+      <div class="hidden lg:flex items-center space-x-3 my-4 right-dropdown">
         {{ range $list }}
-        <a
-          href="{{ .URL }}"
-          class="py-4 px-2 font-semibold text-white hover:opacity-75 {{ if eq $current.URL .URL }} text-link-orange {{ end }}"
-          title="{{ .Title }}"
-        >
-          {{ .Name }}
-        </a>
+          {{ partial "nav_item.html" . }}
         {{ end }}
       </div>
       <!-- Mobile menu button -->

--- a/layouts/partials/header_home.html
+++ b/layouts/partials/header_home.html
@@ -6,33 +6,7 @@
         <!-- Navbar items -->
         <div class="hidden lg:flex items-center space-x-3 my-4">
           {{ range $list }}
-          <ul class="nav-item">
-            <li class="block transition-all duration-75 relative">
-              <a href="{{ .URL | urlize }}"
-                 class="py-2 px-4 font-semibold text-xl text-white hover:text-link-orange border-b-2 border-link-orange border-opacity-0 hover:border-opacity-100"
-                 title="{{ .Title }}">
-                {{ .Name }}
-              </a>
-              {{ if .HasChildren }}
-              <ul class="nav-dropdown py-2">
-                <li>
-                  <div class="flex items-start bg-card-light py-6">
-                    {{ range .Children }}
-                    <div class="mx-6">
-                      <p class="text-link-orange font-bold tracking-wide mb-1">{{ .Name }}</p>
-                      {{ range .Children }}
-                        <a href="{{ .URL }}" class="block font-semibold hover:text-link-orange mb-1">
-                          {{ htmlUnescape (replace .Name " " "&nbsp;") }}
-                        </a>
-                      {{ end }}
-                    </div>
-                    {{ end }}
-                  </div>
-                </li>
-              </ul>
-              {{ end }}
-            </li>
-          </ul>
+            {{ partial "nav_item.html" . }}
           {{ end }}
         </div>
         <!-- Mobile menu button -->

--- a/layouts/partials/nav_item.html
+++ b/layouts/partials/nav_item.html
@@ -1,0 +1,27 @@
+<ul class="nav-item">
+  <li class="block transition-all duration-75 relative">
+    <a href="{{ .URL | urlize }}"
+       class="py-2 px-4 font-semibold text-xl text-white hover:text-link-orange border-b-2 border-link-orange border-opacity-0 hover:border-opacity-100"
+       title="{{ .Title }}">
+      {{ .Name }}
+    </a>
+    {{ if .HasChildren }}
+    <ul class="nav-dropdown py-2">
+      <li>
+        <div class="flex items-start bg-card-light py-6">
+          {{ range .Children }}
+          <div class="mx-6">
+            <p class="text-link-orange font-bold tracking-wide mb-1">{{ .Name }}</p>
+            {{ range .Children }}
+            <a href="{{ .URL }}" class="block font-semibold hover:text-link-orange mb-1">
+              {{ htmlUnescape (replace .Name " " "&nbsp;") }}
+            </a>
+            {{ end }}
+          </div>
+          {{ end }}
+        </div>
+      </li>
+    </ul>
+    {{ end }}
+  </li>
+</ul>


### PR DESCRIPTION
Sorry for the wait! This should add the nav items to their own partial for desktop view on both navbars.

I also added a class called `right-dropdown` to shift the dropdown position (starts right to left, instead of left to right), it's mostly for the second navbar so it doesn't go off screen when there's more content added to it.