### PR TITLE
change: enable purgecss to drastically increase load times

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,7 +1,10 @@
 const plugin = require('tailwindcss/plugin');
 
 module.exports = {
-  purge: ['layouts/**/*.html'],
+    purge: {
+        enabled: true,
+        content: ['layouts/**/*.html']
+    },
   darkMode: false, // or 'media' or 'class'
   theme: {
     fontFamily: {


### PR DESCRIPTION
Enables purgecss to remove unused classes, increasing load times especially on slow internet by a huge margin.

Results: `7754 rules` -> `402 rules.`