### PR TITLE
Bugfix on Stat priority no content

### DIFF
--- a/layouts/partials/cards/_footer.html
+++ b/layouts/partials/cards/_footer.html
@@ -1,7 +1,5 @@
 {{ if isset . "readMoreLink" }}
-<div class="border-t border-card-dark pt-5 text-right">
   <a href="{{ .readMoreLink }}" class="link">
     {{ default "Read more" .readMoreText }} »
   </a>
-</div>
 {{ end }}

--- a/layouts/partials/cards/default.html
+++ b/layouts/partials/cards/default.html
@@ -15,8 +15,10 @@
     <div>
       {{ .text }}
     </div>
-    {{ if isset . "readMoreLink" }}
-      {{ partial "cards/_footer.html" . }}
-    {{ end }}
+    <div class="border-t border-card-dark pt-5 text-right">
+      {{ if isset . "readMoreLink" }}
+        {{ partial "cards/_footer.html" . }}
+      {{ end }}
+    </div>
 	</div>
 </div>

--- a/layouts/partials/job/gearing.html
+++ b/layouts/partials/job/gearing.html
@@ -21,25 +21,25 @@
       </div>
       <div class="xl:col-span-4 text-white">
         {{ with .Page.GetPage "stat-priority" }}
-          {{ if .Content }}
-            {{ $content := dict
+          {{if .Content }}
+            {{ .Scratch.Add "content" (dict
               "role" $role
               "icon" "/theme-assets/materia.svg"
               "name" "Stats & Materia"
               "text" .Params.priority
               "readMoreText" "Why this priority?"
-              "readMoreLink" "stat-priority"
+              "readMoreLink" "stat-priority")
             }}
-            {{ partial "cards/default.html" $content }}
           {{ else }}
-            {{ $content := dict
+            {{ .Scratch.Add "content" (dict
               "role" $role
               "icon" "/theme-assets/materia.svg"
               "name" "Stats & Materia"
-              "text" .Params.priority
+              "text" .Params.priority)
             }}
-            {{ partial "cards/default.html" $content }}
           {{ end }}
+          {{ $content := .Scratch.Get "content" }}
+          {{ partial "cards/default.html" $content }}
         {{ end }}
       </div>
     </section>

--- a/layouts/partials/job/gearing.html
+++ b/layouts/partials/job/gearing.html
@@ -21,15 +21,25 @@
       </div>
       <div class="xl:col-span-4 text-white">
         {{ with .Page.GetPage "stat-priority" }}
-          {{ $content := dict
-            "role" $role
-            "icon" "/theme-assets/materia.svg"
-            "name" "Stats & Materia"
-            "text" .Params.priority
-            "readMoreText" "Why this priority?"
-            "readMoreLink" "stat-priority"
-          }}
-          {{ partial "cards/default.html" $content }}
+          {{ if .Content }}
+            {{ $content := dict
+              "role" $role
+              "icon" "/theme-assets/materia.svg"
+              "name" "Stats & Materia"
+              "text" .Params.priority
+              "readMoreText" "Why this priority?"
+              "readMoreLink" "stat-priority"
+            }}
+            {{ partial "cards/default.html" $content }}
+          {{ else }}
+            {{ $content := dict
+              "role" $role
+              "icon" "/theme-assets/materia.svg"
+              "name" "Stats & Materia"
+              "text" .Params.priority
+            }}
+            {{ partial "cards/default.html" $content }}
+          {{ end }}
         {{ end }}
       </div>
     </section>


### PR DESCRIPTION
This PR fixes the issue where we hide the link to the stat priority page if there is no content.

![image](https://user-images.githubusercontent.com/6521857/142742833-2033d2c8-7d5f-4f90-8af8-a4dd164e7610.png)
