### PR TITLE
Added a partial and shortcode to support etro.gg embeds

### DIFF
--- a/layouts/jobs/bis.html
+++ b/layouts/jobs/bis.html
@@ -21,8 +21,6 @@
         <div class="markdown max-w-none">
           {{ range .Params.bis }}
             <h2><a href="{{ .link }}">{{ .name }}</a></h2>
-            <!-- {{ $link := dict "uuid" (index (last 1 (split .link "/")) 0) }} 
-            {{ partial "components/etro.html" $link}} -->
             {{ .description | markdownify }}
           {{ end }}
         </div>

--- a/layouts/jobs/bis.html
+++ b/layouts/jobs/bis.html
@@ -21,6 +21,8 @@
         <div class="markdown max-w-none">
           {{ range .Params.bis }}
             <h2><a href="{{ .link }}">{{ .name }}</a></h2>
+            <!-- {{ $link := dict "uuid" (index (last 1 (split .link "/")) 0) }} 
+            {{ partial "components/etro.html" $link}} -->
             {{ .description | markdownify }}
           {{ end }}
         </div>

--- a/layouts/partials/components/etro.html
+++ b/layouts/partials/components/etro.html
@@ -1,6 +1,6 @@
 <div class="h-96">
   <iframe class="w-full h-full"
     title="Etro Gearset" 
-    src="https://etro.gg/embed/gearset/{{ .uuid }}">
+    src="https://etro.gg/embed/gearset/{{ . }}">
   </iframe>
 </div>

--- a/layouts/partials/components/etro.html
+++ b/layouts/partials/components/etro.html
@@ -1,0 +1,6 @@
+<div class="h-96">
+  <iframe class="w-full h-full"
+    title="Etro Gearset" 
+    src="https://etro.gg/embed/gearset/{{ .uuid }}">
+  </iframe>
+</div>

--- a/layouts/shortcodes/etro.html
+++ b/layouts/shortcodes/etro.html
@@ -1,0 +1,11 @@
+{{/*
+Shortcode for embedding etro.gg link
+Usage:
+{{< etro uuid >}}
+ */}}
+<div class="h-96">
+  <iframe class="w-full h-full"
+    title="Etro Gearset" 
+    src="https://etro.gg/embed/gearset/{{ .Get 0 }}">
+  </iframe>
+</div>


### PR DESCRIPTION
Addresses #200.

Also included a commented out example in the `bis.html` partial for later use if needed.

I was unsure of the exact size desired so feedback on the width/height of the embed is greatly appreciated. For reference, the current height is 96 rem.