### PR TITLE
min-height for role boxes (plus some mobile styling updates)

### DIFF
--- a/layouts/jobs/role_home.html
+++ b/layouts/jobs/role_home.html
@@ -6,7 +6,7 @@
 {{ partial "role/header.html" . }}
 <div class="responsive-container mt-8 lg:mt-14">
     <h1 class="text-4xl uppercase font-bold tracking-wide">{{ $roleData.nameSingular }} Jobs</h1>
-    <div class="grid grid-cols-1 md:grid-cols-2 md:gap-4 items-start">
+    <div class="grid grid-cols-1 lg:grid-cols-2 md:gap-4 items-start mt-12 mb-8">
       {{ range $roleData.jobs }}
           {{ partial "cards/job_card/job_card.html" (dict "jobData" . "siteVar" $.Site "role" $roleData.name) }}
       {{ end }}

--- a/layouts/partials/cards/job_card/job_card.html
+++ b/layouts/partials/cards/job_card/job_card.html
@@ -23,7 +23,7 @@
   $statPriority
 }}
 
-<div class="mt-0 lg:mt-12">
+<div class="mt-0">
   <div class="flex flex-col w-full py-3 justify-center items-start">
     <div class="card card-{{ $borderClass }} space-y-3 w-full">
       {{ if isset .jobData "name" }}
@@ -31,7 +31,7 @@
           {{ partial "cards/job_card/_header.html" .jobData }}
         </div>
       {{ end }}
-      <div>
+      <div class="min-h-36 flex items-center">
         {{ with .siteVar.GetPage $indexPath}}
           {{ .Content }}
         {{end}}

--- a/layouts/partials/role/header.html
+++ b/layouts/partials/role/header.html
@@ -4,15 +4,15 @@
 <div class="h-auto md:h-84 xl:h-80 flex flex-col lg:flex-row">
   <div class="responsive-container z-10 relative flex flex-col md:flex-row items-center h-full mt-12 md:mt-0">
     <div class="w-full md:w-6/12 flex-grow flex flex-col md:flex-row text-center items-center md:text-left mb-4 lg:pr-8 lg:mb-0">
-      <div class="w-full mr-4 lg:-mr-8 flex self-start">
-        <img class="job-icon-header mb-2 mx-auto md:mx-0 lg:mb-0 xl:mr-8 filter drop-shadow-lg-{{ $role }}" src="/theme-assets/icons/role/role_{{ (lower $role) }}_white.svg" />
+      <div class="w-full xl:w-116 mr-4 lg:mr-0 xl:mr-8 flex self-start">
+        <img class="job-icon-header mb-2 mx-auto md:mx-0 lg:mb-0 filter drop-shadow-lg-{{ $role }}" src="/theme-assets/icons/role/role_{{ (lower $role) }}_white.svg" />
       </div>
       <div class="flex flex-col items-center md:items-start justify-center md:justify-start mt-0">
         <h1 class="text-3xl md:text-4xl xl:text-6xl tracking-wider font-semibold filter drop-shadow-lg-{{ $role }} mb-4">{{ $title }}</h1>
         {{ .Content }}
       </div>
     </div>
-    <div class="mt-0 xl:mt-48 md:w-5/12 flex flex-end justify-center lg:justify-end">
+    <div class="mt-0 lg:mt-40 xl:mt-48 md:w-5/12 flex flex-end justify-center lg:justify-end">
       <img src="{{ .Page.Params.role_hero_image }}" />
     </div>
   </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -77,6 +77,11 @@ module.exports = {
         '116': '29rem',
         '120': '30rem',
       },
+      minHeight: {
+        '0': '0',
+        '36': "9rem",
+        'full': '100%',
+      },
       zIndex: {
           '-1': '-1',
       },


### PR DESCRIPTION
This is more like a band-aid fix to add min-height to the role cards on each job description.

A cleaner way is to implement something like a masonry style to the cards. But this will require incorporating an external JS library. I don't think @nonowazu wants to do that so hopefully this fix can help mitigate some of the height issues.