### PR TITLE
Added fixed height on job logo in role card

### DIFF
--- a/layouts/partials/cards/job_card/_header.html
+++ b/layouts/partials/cards/job_card/_header.html
@@ -1,7 +1,7 @@
 <div class="flex flex-wrap items-center {{ if isset . "inlineLink" }}transform-gpu translate-x-0 group-hover:translate-x-2 transition-all{{ end }}">
   {{ with .icon }}
   <div class="mr-8">
-    <img src="{{ . }}" />
+    <img class="h-12" src="{{ . }}" />
   </div>
   {{ end }}
   <div class="flex flex-grow">


### PR DESCRIPTION
Noticed that SCH and SMN logo were massive lol. Added a fixed height on all job logos in the Role cards to normalize them.