### PR TITLE
fix: jobs -> combat-jobs frontmatter

### DIFF
--- a/exampleSite/content/jobs/casters/_index.md
+++ b/exampleSite/content/jobs/casters/_index.md
@@ -2,7 +2,7 @@
 menu:
   main:
     name: Casters
-    parent: jobs
+    parent: combat-jobs
 role: casters
 layout: role_home
 ---

--- a/exampleSite/content/jobs/healers/_index.md
+++ b/exampleSite/content/jobs/healers/_index.md
@@ -3,7 +3,7 @@ menu:
   main:
     identifier: healers
     name: Healers
-    parent: jobs
+    parent: combat-jobs
 role: healers
 layout: role_home
 ---

--- a/exampleSite/content/jobs/melee/_index.md
+++ b/exampleSite/content/jobs/melee/_index.md
@@ -2,7 +2,7 @@
 menu:
   main:
     name: Melee
-    parent: jobs
+    parent: combat-jobs
 role: melee
 layout: role_home
 ---

--- a/exampleSite/content/jobs/ranged/_index.md
+++ b/exampleSite/content/jobs/ranged/_index.md
@@ -2,7 +2,7 @@
 menu:
   main:
     name: Ranged
-    parent: jobs
+    parent: combat-jobs
 role: ranged
 layout: role_home
 ---

--- a/exampleSite/content/jobs/tanks/_index.md
+++ b/exampleSite/content/jobs/tanks/_index.md
@@ -2,7 +2,7 @@
 menu:
   main:
     name: Tanks
-    parent: jobs
+    parent: combat-jobs
 role: tanks
 layout: role_home
 bg_header_image: /img/jobs/tanks/tanks_background.png


### PR DESCRIPTION
We changed from jobs to combat-jobs for primary job roles in the config a while ago for the navbar, this fixes any instances of jobs being a parent in the exampleSite folder.