### PR TITLE
Add crappy inline shortcode

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -531,3 +531,10 @@ Markdown - Can be used to auto apply styling to tags within the .markdown class
 .markdown table > tbody > tr:nth-of-type(odd) {
 	@apply bg-table-light;
 }
+
+/* shortcode additions */
+.markdown .image-inline {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 5px;
+}

--- a/layouts/shortcodes/inline.html
+++ b/layouts/shortcodes/inline.html
@@ -1,3 +1,3 @@
-<div class="flex">
+<div class="image-inline">
   {{ .Inner | markdownify }}
 </div>

--- a/layouts/shortcodes/inline.html
+++ b/layouts/shortcodes/inline.html
@@ -1,0 +1,3 @@
+<div class="flex">
+  {{ .Inner | markdownify }}
+</div>


### PR DESCRIPTION
This just adds a shortcode that will make all images stack horizontally instead of vertically. It's not pretty, so this requires styling discussion and etc.

Given the following markdown:
```markdown
{{< inline >}}
![True Thrust](https://xivapi.com/i/000000/000310_hr1.png)
![Disembowel](https://xivapi.com/i/000000/000317_hr1.png)
![Chaos Thrust](https://xivapi.com/i/000000/000308_hr1.png)
{{< /inline >}}
```

This will generate:

```html
<div class="flex">
  <img src="https://xivapi.com/i/000000/000310_hr1.png" alt="True Thrust">
<img src="https://xivapi.com/i/000000/000317_hr1.png" alt="Disembowel">
<img src="https://xivapi.com/i/000000/000308_hr1.png" alt="Chaos Thrust">
</div>
```


However, given that this is a ugly solution, maybe we need something more like:

```markdown
{{< flex >}}
    {{< flexItem >}}
        ![True Thrust](https://xivapi.com/i/000000/000310_hr1.png)
    {{< /flexItem >}}
    {{< flexItem >}}
        ![Disembowel](https://xivapi.com/i/000000/000317_hr1.png)
    {{< /flexItem >}}
    {{< flexItem >}}
        ![Chaos Thrust](https://xivapi.com/i/000000/000308_hr1.png)
    {{< /flexItem >}}
{{< /flex >}}
```

Which is more gross on markup, but at least allows more control of the final generated html (given that we allow options on flexItem and etc)