### PR TITLE
Add role links on nav menu (desktop + mobile)

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -56,7 +56,7 @@
                 <div class="flex flex-wrap flex-row items-start bg-card-light">
                   {{ range .Children }}
                   <div class="w-1/2 sm:w-1/3 lg:w-auto mb-4">
-                    <p class="text-link-orange font-bold tracking-wide mb-1 text-base">{{ .Name }}</p>
+                    <a href="{{ .URL }}" class="text-link-orange font-bold tracking-wide block mb-2 text-base">{{ .Name }}<a>
                     {{ range .Children }}
                     <a href="{{ .URL }}" class="block text-white hover:text-link-orange mb-1 text-base">
                       {{ htmlUnescape (replace .Name " " "&nbsp;") }}

--- a/layouts/partials/header_home.html
+++ b/layouts/partials/header_home.html
@@ -37,7 +37,7 @@
                 <div class="flex flex-wrap flex-row items-start bg-card-light">
                   {{ range .Children }}
                   <div class="w-1/2 sm:w-1/3 lg:w-auto mb-4">
-                    <p class="text-link-orange font-bold tracking-wide mb-1 text-base">{{ .Name }}</p>
+                    <a href="{{ .URL }}" class="text-link-orange font-bold tracking-wide block mb-2 text-base">{{ .Name }}</a>
                     {{ range .Children }}
                     <a href="{{ .URL }}" class="block text-white hover:text-link-orange mb-1 text-base">
                       {{ htmlUnescape (replace .Name " " "&nbsp;") }}

--- a/layouts/partials/nav_item.html
+++ b/layouts/partials/nav_item.html
@@ -11,7 +11,7 @@
         <div class="flex items-start bg-card-light py-6">
           {{ range .Children }}
           <div class="mx-6">
-            <p class="text-link-orange font-bold tracking-wide mb-1">{{ .Name }}</p>
+            <a href="{{ .URL }}" class="text-link-orange font-bold tracking-wide block mb-2">{{ .Name }}</a>
             {{ range .Children }}
             <a href="{{ .URL }}" class="block font-semibold hover:text-link-orange mb-1">
               {{ htmlUnescape (replace .Name " " "&nbsp;") }}


### PR DESCRIPTION
This PR will add a hyperlink on the navigation menu when a user clicks on any of the role titles from the dropdown / mobile menu.