### PR TITLE
Change up bis to support displaying etro sets better

### DIFF
--- a/exampleSite/content/jobs/healers/scholar/best-in-slot.md
+++ b/exampleSite/content/jobs/healers/scholar/best-in-slot.md
@@ -10,20 +10,20 @@ changelog:
 bis:
   - name: Comfy 2.42 spell speed (high piety)
     type: etro
-    link: https://etro.gg/gearset/4f21e0e3-d02e-4c58-a11d-a5cb062efcf8
+    link: 6c93e15c-6d23-4e41-b524-fdd57b185201
     description: |
       No problems - useful for any kind of content
   - name: Hardcore low-piety set
     type: etro
-    link: https://etro.gg/gearset/4f21e0e3-d02e-4c58-a11d-a5cb062efcf8
+    link: 6c93e15c-6d23-4e41-b524-fdd57b185201
     description: |
       **Do not use this unless you know what you're doing**
   - name: "'Nuff said"
     type: etro
-    link: https://etro.gg/gearset/4f21e0e3-d02e-4c58-a11d-a5cb062efcf8
+    link: 6c93e15c-6d23-4e41-b524-fdd57b185201
   - type: etro
     name: another set
-    link: https://etro.gg/gearset/4f21e0e3-d02e-4c58-a11d-a5cb062efcf8
+    link: 6c93e15c-6d23-4e41-b524-fdd57b185201
     description: |-
       *a markdown description, with more text*
 

--- a/exampleSite/static/admin/config.yml
+++ b/exampleSite/static/admin/config.yml
@@ -562,7 +562,7 @@ collections:
             fields:
               - {label: "Name", name: "name", widget: "string"}
               - {label: "Type", name: "type", widget: "select", options: ["etro"], default: "etro"}
-              - {label: "Link", name: "link", widget: "string"}
+              - {label: "Set id", name: "link", widget: "string"}
               - {label: "Description", name: "description", widget: "markdown", required: false, default: ""}
       - label: "Stat Priority"
         name: "stat-priority"

--- a/layouts/jobs/bis.html
+++ b/layouts/jobs/bis.html
@@ -22,9 +22,10 @@
       </div>
       <div class="job-guides-container">
         <div class="markdown max-w-none">
-          {{ range .Params.bis }}
-            <h2><a href="{{ .link }}">{{ .name }}</a></h2>
-            {{ .description | markdownify }}
+          {{ range $index, $bis := .Params.bis }}
+            <h2 id="{{ $index }}">{{ $bis.name }}</h2>
+            {{ partial "components/etro.html" $bis.link }}
+            {{ $bis.description | markdownify }}
           {{ end }}
         </div>
       </div>


### PR DESCRIPTION
This PR (in no particular order):

* fixes a bug with heading anchors (the bug being that they didn't exist)
* changes the format from the link to the etro set being in the h1 to using our etro partial to embed the set (much cleaner IMO)
* Changes the *name*, but not the frontmatter param name (though we probably should, but what if we wanted to support, say, etro and a raw link?)

Either way, waiting on feedback.