### PR TITLE
Add styling for markdown quotes

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -525,6 +525,16 @@ Markdown - Can be used to auto apply styling to tags within the .markdown class
 	@apply bg-table-light;
 }
 
+.markdown blockquote {
+	border-left: 4px solid #ccc;
+	margin: 1.5em 10px;
+	padding: 0.5em 10px;
+}
+
+.markdown blockquote p {
+	display: inline;
+}
+
 /* shortcode additions */
 .markdown .image-inline {
 	display: flex;


### PR DESCRIPTION
i.e.

```md
> Here's a quote
>> Nested quote
```

renders to:

![image](https://user-images.githubusercontent.com/65056303/150690598-c1ca7f59-ca5c-4094-939d-b15e4c4751f8.png)
