### PR TITLE
Fix malformed google font link

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -17,7 +17,7 @@
 <title>{{ .Site.Title }}{{ with .Title }} | {{ . }}{{ end }}</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Kumbh+Sans:wght@100,700&family=Roboto:ital,wght@0,100,400;0,700;1,400&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Kumbh+Sans:wght@100;700&family=Roboto:ital,wght@0,100;0,400;0,700;1,100;1,400;1,700&display=swap" rel="stylesheet">
 {{ $styles := resources.Get "css/main.css" | postCSS }}
 {{ $headerJs := resources.Get "js/header.js" }}
 {{ $navJs := resources.Get "js/nav.js" }}


### PR DESCRIPTION
The production site is currently attempting to load `Kumbh Sans` and `Roboto` font faces from google fonts, the request for which is failing:

<img width="1840" alt="Screenshot 2022-02-02 at 01 09 00" src="https://user-images.githubusercontent.com/7144173/152077677-aea0450a-5e6b-4bd8-97cd-d5b340f46865.png">

this is because the URL is formatted incorrectly:
```
400: Invalid selector

Too many values in tuple

Kumbh Sans:wght@100,700
                    ^
```

### This PR:
* Updates the font link to one with correctly formatted query params, which results in:
  * `Kumbh Sans` @ 100
  * `Kumbh Sans` @ 700
  * `Roboto` @ 100
  * `Roboto` @ 400
  * `Roboto` @ 700
  * `Roboto Italic` @ 100
  * `Roboto Italic` @ 400
  * `Roboto Italic` @ 700
    * I'm not exactly certain what this url was trying to import before but this feels close enough, and due to how font faces work we don't pay the cost of loading them if they're not used in the css for the page


<img width="1840" alt="Screenshot 2022-02-02 at 01 10 41" src="https://user-images.githubusercontent.com/7144173/152077690-a747cd9e-c97d-4bc1-b407-cb54fafccfce.png">
