### PR TITLE
Fix author list on medium breakpoints

### DIFF
--- a/layouts/partials/components/guide_meta_slider.html
+++ b/layouts/partials/components/guide_meta_slider.html
@@ -23,7 +23,7 @@
       <div class="tab-content meta-content">
         {{ partial "components/questions.html" (dict "discord" $discord)}}
         <div class="card-title mb-5">Authors</div>
-        <div class="flex flex-row flex-wrap xl:flex-nowrap xl:gap-12">
+        <div class="flex flex-row flex-wrap xl:flex-nowrap xl:gap-12 w-full">
           {{ range $author := $.Page.Params.authors }}
           {{ partial "components/author_box.html" (index $.Site.Data.author $author) }}
           {{ end }}


### PR DESCRIPTION
The list of authors currently squishes avatars + names on top of eachother in the medium breakpoint:
<img width="341" alt="Screenshot 2022-02-02 at 01 42 48" src="https://user-images.githubusercontent.com/7144173/152080676-f807fdf5-304a-4d2c-bd36-22a42dc81432.png">

### This PR:
* allows this container to expand to the full width of _its_ parent such that the % widths of the author_box can make sense at the different responsive breakpoints
https://github.com/The-Balance-FFXIV/glam/blob/086e4f2f5384c58a454bb0dada729364a4593e88/layouts/partials/components/author_box.html#L1

<img width="708" alt="Screenshot 2022-02-02 at 01 50 24" src="https://user-images.githubusercontent.com/7144173/152080945-88d82f4c-7bb0-4796-9b25-2d9372d3a2af.png">
