### PR TITLE
Include some regex magic to fix broken links

### DIFF
--- a/layouts/partials/components/etro.html
+++ b/layouts/partials/components/etro.html
@@ -1,6 +1,6 @@
 <div class="h-96">
   <iframe class="w-full h-full"
     title="Etro Gearset" 
-    src="https://etro.gg/embed/gearset/{{ . }}">
+    src="https://etro.gg/embed/gearset/{{ replaceRE "^https?://etro\.gg/gearset/" "" . }}">
   </iframe>
 </div>


### PR DESCRIPTION
This change should catch full links and strip it to only the id that is needed