### PR TITLE
Adjust table styling

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -63,11 +63,11 @@ header nav {
 	height: 100%;
 }
 
-ul.nav-item li ul.nav-dropdown{
+ul.nav-item li ul.nav-dropdown {
 	@apply lg:invisible lg:opacity-0 lg:absolute transition-all delay-75 left-0 mt-1 hidden;
 }
 
-div.right-dropdown ul.nav-item li ul.nav-dropdown{
+div.right-dropdown ul.nav-item li ul.nav-dropdown {
 	right: 0;
 	left: auto !important;
 }
@@ -77,7 +77,7 @@ ul.nav-item li ul:hover{
 	@apply lg:visible lg:opacity-100 lg:block;
 }
 
-ul.nav-item li ul.nav-dropdown li{
+ul.nav-item li ul.nav-dropdown li {
 	clear: both;
 	width: 100%;
 }
@@ -233,17 +233,46 @@ Content
 
 
 /* tables */
-#content td img {
+#content table td img {
 	min-width: 3rem;
 }
 
-#content table, #content .codeblock {
+#content .codeblock {
 	display: block;
 	max-width: -moz-fit-content;
 	max-width: fit-content;
 	margin: 0 auto;
-	overflow-x: auto;
-	white-space: nowrap;
+}
+
+#content table {
+	display: block;
+	max-width: -moz-fit-content;
+	max-width: fit-content;
+	margin: 0 auto;
+	border: 2px solid #2a2a2a;
+	border-collapse: collapse;
+	width: 100%;
+}
+
+#content table tr {
+	padding: .35em;
+}
+
+#content table th, #content table td {
+	padding: .625em;
+	text-align: center;
+}
+
+#content table th {
+	font-size: .85em;
+	letter-spacing: .1em;
+	text-transform: uppercase;
+}
+
+@media screen and (max-width: 600px) {
+	#content table, #content .codeblock {
+		overflow-x: auto;
+	}
 }
 
 /*


### PR DESCRIPTION
This PR fixes the desktop table styling while still allowing for horizontal overflow on mobile devices. The UX issue for mobile devices remains and will need to be addressed separately.

Before:
Desktop
![image](https://user-images.githubusercontent.com/65056303/169420414-e0f7a9a5-4f89-444e-9ca3-dbb0d5448847.png)


Mobile (table overflows and must be horizontally scrolled to be readable)
![image](https://user-images.githubusercontent.com/65056303/169420037-c8ff6e24-a134-44ad-84cf-a11def05a902.png)

After:
Desktop
![image](https://user-images.githubusercontent.com/65056303/169420065-d8a4a9f3-492a-4f6d-aff1-f34689d2bd82.png)

Mobile (table is taller and narrower without white-space wrapping, but still overflows)
![image](https://user-images.githubusercontent.com/65056303/169420094-a0b8f2be-16d1-44c6-91c6-ce16e2e4e3f2.png)


