### PR TITLE
proof of concept accurate previews for job landing

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Glam is a theme for The Balance website put together by the wonderful FFXIV comm
 
 ## Testing the theme locally
 
-Make sure you have [hugo](https://gohugo.io/getting-started/installing/) installed, either drop `hugo.exe` in the root dir or add it to your PATH.
+Make sure you have [hugo](https://gohugo.io/getting-started/installing/) installed, either drop `hugo.exe` in the root dir or add it to your PATH. Make sure you're using hugo version [v0.86.1](https://github.com/gohugoio/hugo/releases/tag/v0.86.1)
 
 ```sh
 # Clone the repository
@@ -14,8 +14,8 @@ git clone https://github.com/The-Balance-FFXIV/glam.git
 cd ./glam/
 
 # Install project dependencies and dependencies. If you prefer to not edit PATH, you can install globally.
-export PATH=$PATH:node_modules/.bin
-yarn install
+export PATH=$PATH:${PWD}/node_modules/.bin
+yarn
 
 # Run the servers
 yarn start:static
@@ -23,13 +23,13 @@ yarn start:static
 # Server starts by default on `localhost:1313`
 ```
 
-
 ## Using the editor locally
 
 First run the static site server with `yarn start:static`, then run `yarn start:admin` and navigate to `http://localhost:1313/admin`.
 Alternatively, `yarn start` will start both servers.
 
 # The wiggly bits
+
 This is some general documentation until we can clean it out.
 
 ## Adding an item to the footer
@@ -38,6 +38,6 @@ Currently, the configuration for the footer is under exampleSite/config.toml.
 
 If you want to add a new column, add it here.
 
-Updating an entry: add it as a folder into exampleSite/content/*. You'll need to 
-add an ``_index.md`` that will then list out the parent for that item, and other information
+Updating an entry: add it as a folder into exampleSite/content/\*. You'll need to
+add an `_index.md` that will then list out the parent for that item, and other information
 that you want to associate with it.

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -628,7 +628,10 @@ ol {
   @apply list-disc pl-10 space-y-2 mb-8;
 }
 
-.markdown ul ul {
+.markdown ul ul,
+.markdown ul ol,
+.markdown ol ul,
+.markdown ol ol {
   margin-bottom: 0;
 }
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -7,25 +7,23 @@
  */
 
 body {
-	@apply font-sans text-white;
-	background-color: #222528;
-	display: flex;
-	flex-direction: column;
-	min-height: 100vh;
+  @apply font-sans text-white;
+  background-color: #222528;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
 }
 
 html {
-	scroll-behavior: smooth;
+  scroll-behavior: smooth;
 }
-
 
 /*
 *  Container (Mobile + Desktop)
 */
 .responsive-container {
-	@apply container px-4 lg:px-8 mx-auto;
+  @apply container px-4 lg:px-8 mx-auto;
 }
-
 
 /*
 Header/Navbar
@@ -33,126 +31,125 @@ Header/Navbar
 
 header,
 .general-page-bg {
-	background-image: url("/theme-assets/homepage/endwalker@2x.png");
+  background-image: url("/theme-assets/homepage/endwalker@2x.png");
 }
 header::after,
 .general-page-bg:after {
-	content:'';
-	position:absolute;
-	top:0;
-	left:0;
-	width:100%;
-	height:100%;
-	background: #0E263D;
-	opacity:0.65;
-	z-index:-1;
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: #0e263d;
+  opacity: 0.65;
+  z-index: -1;
 }
 
 header nav {
-	@apply font-head;
+  @apply font-head;
 }
 
 .navbar {
-	height: 80px;
-	background: #000000;
-	opacity: 1;
+  height: 80px;
+  background: #000000;
+  opacity: 1;
 }
 
 .navbar-container {
-	@apply container mx-auto;
-	height: 100%;
+  @apply container mx-auto;
+  height: 100%;
 }
 
 ul.nav-item li ul.nav-dropdown {
-	@apply lg:invisible lg:opacity-0 lg:absolute transition-all delay-75 left-0 mt-1 hidden;
+  @apply lg:invisible lg:opacity-0 lg:absolute transition-all delay-75 left-0 mt-1 hidden;
 }
 
 div.right-dropdown ul.nav-item li ul.nav-dropdown {
-	right: 0;
-	left: auto !important;
+  right: 0;
+  left: auto !important;
 }
 
 ul.nav-item li:hover > ul.nav-dropdown,
-ul.nav-item li ul:hover{
-	@apply lg:visible lg:opacity-100 lg:block;
+ul.nav-item li ul:hover {
+  @apply lg:visible lg:opacity-100 lg:block;
 }
 
 ul.nav-item li ul.nav-dropdown li {
-	clear: both;
-	width: 100%;
+  clear: both;
+  width: 100%;
 }
 
 /**
 Link
  */
 
- .orange-link {
-	 @apply text-link-orange font-bold tracking-wide;
- }
-
+.orange-link {
+  @apply text-link-orange font-bold tracking-wide;
+}
 
 /**
 Heading
  */
 
- .section-head {
-	@apply h-shadow flex-grow text-4xl font-head tracking-wider uppercase font-bold;
+.section-head {
+  @apply h-shadow flex-grow text-4xl font-head tracking-wider uppercase font-bold;
 }
 
 .nav-item {
-	font-size: 16px;
+  font-size: 16px;
 }
 
 .responsive-container.mobile-menu {
-	@apply bg-card-light px-0 mx-0 lg:hidden w-full;
-	max-width:100%;
+  @apply bg-card-light px-0 mx-0 lg:hidden w-full;
+  max-width: 100%;
 }
 
 .mobile-menu > ul > li {
-	@apply border-t border-nav-border text-lg lg:border-none px-4 sm:px-8;
+  @apply border-t border-nav-border text-lg lg:border-none px-4 sm:px-8;
 }
 
 .mobile-menu > ul > li.nav-active,
 .mobile-menu > ul > li.nav-active > a {
-	@apply border-link-orange text-link-orange;
+  @apply border-link-orange text-link-orange;
 }
 
 .mobile-menu > ul > li > .chevron {
-	background-image: url("/theme-assets/chevron-down.svg");
-	background-position: right 50%;
-	background-repeat: no-repeat;
+  background-image: url("/theme-assets/chevron-down.svg");
+  background-position: right 50%;
+  background-repeat: no-repeat;
 }
 
 .mobile-menu > ul > li.nav-active > .chevron {
-	background-image: url("/theme-assets/chevron-up.svg");
+  background-image: url("/theme-assets/chevron-up.svg");
 }
 
 /**
 Table of Contents
  */
 
- nav#TableOfContents ul a + ul {
-	padding-left: 1.5em;
-	max-height: 0;
-	overflow: hidden;
-	display: block;
-	transition: max-height 0.4s;
+nav#TableOfContents ul a + ul {
+  padding-left: 1.5em;
+  max-height: 0;
+  overflow: hidden;
+  display: block;
+  transition: max-height 0.4s;
 }
 
 nav#TableOfContents ul a + ul.active {
-	max-height: 1000px;
-	display: block;
-	padding-top: 0.2em;
-	padding-bottom: 0.2em;
-	transition: max-height 1s;
+  max-height: 1000px;
+  display: block;
+  padding-top: 0.2em;
+  padding-bottom: 0.2em;
+  transition: max-height 1s;
 }
 
 nav#TableOfContents a {
-	font-size: 0.925rem;
+  font-size: 0.925rem;
 }
 
 nav#TableOfContents a.active {
-	color: white;
+  color: white;
 }
 
 /**
@@ -160,119 +157,119 @@ Modal markdown images
  */
 
 .md__image {
-	cursor: pointer;
+  cursor: pointer;
 }
 
 /* The Modal (background) */
 .modal {
-	display: none;
-	position: fixed;
-	padding-top: 4em;
-	left: 0;
-	top: 0;
-	width: 100%;
-	height: 100%;
-	overflow: auto;
-	background-color: black;
+  display: none;
+  position: fixed;
+  padding-top: 4em;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+  background-color: black;
 }
 
 /* Modal Content */
 .modal-content {
-	position: relative;
-	background-color: black;
-	margin: auto;
-	padding: 0;
-	width: 90%;
-	max-width: 1400px;
+  position: relative;
+  background-color: black;
+  margin: auto;
+  padding: 0;
+  width: 90%;
+  max-width: 1400px;
 }
-  
+
 .modal-pic {
-	display: flex;
-	align-content: center;
-	cursor: pointer;
+  display: flex;
+  align-content: center;
+  cursor: pointer;
 }
 
 /* The Close Button */
 /* Optimized for accessibility by using a button named close but 	
 	shifting the close text out of the button and only showing x */
-.modal-close {	
-	color: white;
-	background-color: black;
-	position: absolute;
-	top: .5em;
-	right: .5em;
-	font-size: 2em;
-	font-weight: bold;
-	height: 1em;
-	width: 1em;
-	text-indent: 10em;
-	overflow: hidden;
-	border: 0;
+.modal-close {
+  color: white;
+  background-color: black;
+  position: absolute;
+  top: 0.5em;
+  right: 0.5em;
+  font-size: 2em;
+  font-weight: bold;
+  height: 1em;
+  width: 1em;
+  text-indent: 10em;
+  overflow: hidden;
+  border: 0;
 }
 
 .modal-close::after {
-	position: absolute;
-	line-height: 0.5;
-	top: 0.2em;
-	left: 0.1em;
-	text-indent: 0;
-	content: "\00D7"
-}
-  
-.modal-close:hover,
-.modal-close:focus {
-	color: #999;
-	text-decoration: none;
-	cursor: pointer;
+  position: absolute;
+  line-height: 0.5;
+  top: 0.2em;
+  left: 0.1em;
+  text-indent: 0;
+  content: "\00D7";
 }
 
+.modal-close:hover,
+.modal-close:focus {
+  color: #999;
+  text-decoration: none;
+  cursor: pointer;
+}
 
 /**
 Content
  */
 
-
 /* tables */
 #content table td img {
-	min-width: 3rem;
+  min-width: 3rem;
 }
 
 #content .codeblock {
-	display: block;
-	max-width: -moz-fit-content;
-	max-width: fit-content;
-	margin: 0 auto;
+  display: block;
+  max-width: -moz-fit-content;
+  max-width: fit-content;
+  margin: 0 auto;
 }
 
 #content table {
-	display: block;
-	max-width: -moz-fit-content;
-	max-width: fit-content;
-	margin: 0 auto;
-	border: 2px solid #2a2a2a;
-	border-collapse: collapse;
-	width: 100%;
+  display: block;
+  max-width: -moz-fit-content;
+  max-width: fit-content;
+  margin: 0 auto;
+  border: 2px solid #2a2a2a;
+  border-collapse: collapse;
+  width: 100%;
 }
 
 #content table tr {
-	padding: .35em;
+  padding: 0.35em;
 }
 
-#content table th, #content table td {
-	padding: .625em;
-	text-align: center;
+#content table th,
+#content table td {
+  padding: 0.625em;
+  text-align: center;
 }
 
 #content table th {
-	font-size: .85em;
-	letter-spacing: .1em;
-	text-transform: uppercase;
+  font-size: 0.85em;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
 }
 
 @media screen and (max-width: 600px) {
-	#content table, #content .codeblock {
-		overflow-x: auto;
-	}
+  #content table,
+  #content .codeblock {
+    overflow-x: auto;
+  }
 }
 
 /*
@@ -285,98 +282,98 @@ Content
 .role-header-melee,
 .role-header-ranged,
 .role-header-casters {
-	@apply font-bold text-white text-2xl md:text-4xl filter uppercase font-head tracking-wider;
+  @apply font-bold text-white text-2xl md:text-4xl filter uppercase font-head tracking-wider;
 }
 
 .role-header {
-	@apply drop-shadow-lg;
+  @apply drop-shadow-lg;
 }
 
 .role-header-healers {
-    @apply drop-shadow-lg-healers;
+  @apply drop-shadow-lg-healers;
 }
 
 .role-header-tanks {
-    @apply drop-shadow-lg-tanks;
+  @apply drop-shadow-lg-tanks;
 }
 
 .role-header-melee {
-    @apply drop-shadow-lg-melee;
+  @apply drop-shadow-lg-melee;
 }
 
 .role-header-ranged {
-    @apply drop-shadow-lg-ranged;
+  @apply drop-shadow-lg-ranged;
 }
 
 .role-header-casters {
-    @apply drop-shadow-lg-casters;
+  @apply drop-shadow-lg-casters;
 }
 
 .role-info {
-	@apply flex flex-col w-full lg:w-4/12 xl:w-1/4 text-center justify-center;
+  @apply flex flex-col w-full lg:w-4/12 xl:w-1/4 text-center justify-center;
 }
 
 /*
 * TABS
 */
 .tabbed {
-	@apply overflow-x-hidden my-4 pb-2 -mt-16;
+  @apply overflow-x-hidden my-4 pb-2 -mt-16;
 }
 
 .tabbed [type="radio"] {
-	/* hiding the inputs */
-	@apply hidden;
+  /* hiding the inputs */
+  @apply hidden;
 }
 
 .tabs {
-	@apply flex items-stretch font-head p-0 list-none flex-col md:flex-row border-b border-card-light;
+  @apply flex items-stretch font-head p-0 list-none flex-col md:flex-row border-b border-card-light;
 }
 
 .tab-jobs {
-	@apply items-center block md:flex md:flex-wrap md:flex-grow w-full lg:w-1/2 md:justify-evenly font-head mt-4 lg:mt-0;
+  @apply items-center block md:flex md:flex-wrap md:flex-grow w-full lg:w-1/2 md:justify-evenly font-head mt-4 lg:mt-0;
 }
 
 .tabs.desktop {
-	@apply hidden md:flex items-stretch p-0 list-none flex-col md:flex-row divide-x divide-card-dark md:divide-x-0;
+  @apply hidden md:flex items-stretch p-0 list-none flex-col md:flex-row divide-x divide-card-dark md:divide-x-0;
 }
 
 .tab.desktop > label {
-	@apply hidden md:block border-card-dark border-r border-b;
+  @apply hidden md:block border-card-dark border-r border-b;
 }
 .tab.desktop:first-of-type > label {
-	@apply border-l;
+  @apply border-l;
 }
 
 .tab > label {
-	@apply block md:hidden px-7 py-3 cursor-pointer text-xl font-bold text-white uppercase tracking-widest bg-card-lighter transition-all;
+  @apply block md:hidden px-7 py-3 cursor-pointer text-xl font-bold text-white uppercase tracking-widest bg-card-lighter transition-all;
 }
 
 .tab-content {
-	@apply hidden p-4 md:p-8;
+  @apply hidden p-4 md:p-8;
 }
 
 .tab-job-container {
-	@apply flex flex-col w-auto py-3 md:w-1/2 xl:w-auto justify-center items-start md:items-center;
+  @apply flex flex-col w-auto py-3 md:w-1/2 xl:w-auto justify-center items-start md:items-center;
 }
 
 .tab-job-link {
-	@apply flex flex-row items-center w-full md:flex-col md:text-center py-1 md:px-4 md:py-6 md:rounded md:transition-all;
+  @apply flex flex-row items-center w-full md:flex-col md:text-center py-1 md:px-4 md:py-6 md:rounded md:transition-all;
 }
 
 .meta-tabs {
-	@apply flex-col;
+  @apply flex-col;
 }
 
 .meta-tab {
-	@apply w-full;
+  @apply w-full;
 }
 
 .meta-tabs > .meta-tab > label {
-	@apply border-r-0 border-card-dark border-t-2;
+  @apply border-r-0 border-card-dark border-t-2;
 }
 
 .tab-content.meta-content {
-	@apply hidden bg-card-dark px-8 py-8 w-full flex-col items-start;
+  @apply hidden bg-card-dark px-8 py-8 w-full flex-col items-start;
 }
 
 /*
@@ -385,8 +382,8 @@ It unfortunately also means we're limited to 5 tabs at current.
 */
 
 #content .meta-content {
-	/* force .meta-content to not obey the h-120 below. */
-	@apply h-auto;
+  /* force .meta-content to not obey the h-120 below. */
+  @apply h-auto;
 }
 
 /* this is styling for tabs that are checked */
@@ -394,21 +391,45 @@ It unfortunately also means we're limited to 5 tabs at current.
 .tabbed [type="radio"]:nth-of-type(2):checked ~ .tabs .tab:nth-of-type(2) label,
 .tabbed [type="radio"]:nth-of-type(3):checked ~ .tabs .tab:nth-of-type(3) label,
 .tabbed [type="radio"]:nth-of-type(4):checked ~ .tabs .tab:nth-of-type(4) label,
-.tabbed [type="radio"]:nth-of-type(5):checked ~ .tabs .tab:nth-of-type(5) label {
-	@apply bg-card-light border-card-dark md:border-r;
-	border-bottom-color: #19191A;
+.tabbed
+  [type="radio"]:nth-of-type(5):checked
+  ~ .tabs
+  .tab:nth-of-type(5)
+  label {
+  @apply bg-card-light border-card-dark md:border-r;
+  border-bottom-color: #19191a;
 }
 
-.tabbed [type="radio"]:nth-of-type(1):checked ~ .tabs > .tab:nth-of-type(1) > .tab-content,
-.tabbed [type="radio"]:nth-of-type(2):checked ~ .tabs > .tab:nth-of-type(2) > .tab-content,
-.tabbed [type="radio"]:nth-of-type(3):checked ~ .tabs > .tab:nth-of-type(3) > .tab-content,
-.tabbed [type="radio"]:nth-of-type(4):checked ~ .tabs > .tab:nth-of-type(4) > .tab-content,
-.tabbed [type="radio"]:nth-of-type(5):checked ~ .tabs > .tab:nth-of-type(5) > .tab-content {
-	@apply flex bg-card-light content-center xl:h-120;
+.tabbed
+  [type="radio"]:nth-of-type(1):checked
+  ~ .tabs
+  > .tab:nth-of-type(1)
+  > .tab-content,
+.tabbed
+  [type="radio"]:nth-of-type(2):checked
+  ~ .tabs
+  > .tab:nth-of-type(2)
+  > .tab-content,
+.tabbed
+  [type="radio"]:nth-of-type(3):checked
+  ~ .tabs
+  > .tab:nth-of-type(3)
+  > .tab-content,
+.tabbed
+  [type="radio"]:nth-of-type(4):checked
+  ~ .tabs
+  > .tab:nth-of-type(4)
+  > .tab-content,
+.tabbed
+  [type="radio"]:nth-of-type(5):checked
+  ~ .tabs
+  > .tab:nth-of-type(5)
+  > .tab-content {
+  @apply flex bg-card-light content-center xl:h-120;
 }
 
 #meta-slider {
-	@apply flex-col h-auto;	
+  @apply flex-col h-auto;
 }
 
 /*
@@ -416,116 +437,115 @@ It unfortunately also means we're limited to 5 tabs at current.
 */
 
 .card-title {
-    @apply font-bold text-white text-lg uppercase tracking-widest font-head;
+  @apply font-bold text-white text-lg uppercase tracking-widest font-head;
 }
 
 .card-content {
-	@apply flex flex-row font-sans gap-3;
-	border-color: #2a3641;
+  @apply flex flex-row font-sans gap-3;
+  border-color: #2a3641;
 }
 
 .card-content-title {
-	@apply font-bold text-white text-lg pt-3 pr-3;
+  @apply font-bold text-white text-lg pt-3 pr-3;
 }
 
 .card-content-patch {
-	@apply font-bold text-card-header-text-color;
+  @apply font-bold text-card-header-text-color;
 }
 
 .card-content-updated {
-	@apply font-bold text-card-header-text-color pb-3;
+  @apply font-bold text-card-header-text-color pb-3;
 }
-.card-flex-col-wrapper{
-	@apply flex flex-col divide-y-2 border-l-8 divide-line-divide-color border-card-border-color;
-}
-
-.extra-content{
-	@apply text-white pl-3 pb-3;
+.card-flex-col-wrapper {
+  @apply flex flex-col divide-y-2 border-l-8 divide-line-divide-color border-card-border-color;
 }
 
-.content-link{
-	@apply text-right pt-1 pb-3 text-link-orange font-bold;
+.extra-content {
+  @apply text-white pl-3 pb-3;
 }
 
-.extra-list-item{
-	@apply py-1.5;
+.content-link {
+  @apply text-right pt-1 pb-3 text-link-orange font-bold;
 }
 
-.extra-list-item a{
-	@apply text-link-orange font-semibold;
+.extra-list-item {
+  @apply py-1.5;
+}
+
+.extra-list-item a {
+  @apply text-link-orange font-semibold;
 }
 
 .bis-item {
-	@apply text-link-orange font-semibold;
+  @apply text-link-orange font-semibold;
 }
 
 .link {
-    @apply text-link-orange font-semibold hover:underline;
+  @apply text-link-orange font-semibold hover:underline;
 }
 
 .nested-link a {
-    @apply link;
+  @apply link;
 }
 
 /**
 Footer
  */
 
-
 .footer {
-	@apply bg-card-light z-50 mt-auto;
+  @apply bg-card-light z-50 mt-auto;
 }
 
 .footer a {
-	@apply text-link-orange;
-	font-size: 17px;
+  @apply text-link-orange;
+  font-size: 17px;
 }
 
 .footer a:hover {
-	text-decoration: underline;
+  text-decoration: underline;
 }
 
 .footer ul li {
-	padding: .1em 0;
+  padding: 0.1em 0;
 }
 
 .footer-header {
-	@apply text-white font-head mb-0 pb-1 font-bold;
-	font-size: 14px;
-	text-transform: uppercase;
-	letter-spacing: 2.8px;
+  @apply text-white font-head mb-0 pb-1 font-bold;
+  font-size: 14px;
+  text-transform: uppercase;
+  letter-spacing: 2.8px;
 }
 
 .footer-list {
-	@apply mb-8;
+  @apply mb-8;
 }
 
 .footer-copyright {
-	@apply text-center text-sm font-light;
-	color: #8f99a4;
+  @apply text-center text-sm font-light;
+  color: #8f99a4;
 }
 
-.guide-banner-background{
-    @apply w-full bg-cover;
-    background-repeat: no-repeat;
-    /*height: 309px; /* need a better way than fixing it to the size of the image */
+.guide-banner-background {
+  @apply w-full bg-cover;
+  background-repeat: no-repeat;
+  /*height: 309px; /* need a better way than fixing it to the size of the image */
 }
 
 .job-icon-sm {
-    height: 35px;
-    width: 35px;
+  height: 35px;
+  width: 35px;
 }
 
 .job-icon-header {
-    width: 60px;
-	height: 60px;
+  width: 60px;
+  height: 60px;
 }
 
 @screen md {
-	.job-icon-header {
-		width: 100%;
-		height: 100%;
-	}
+  .job-icon-header {
+    width: 100%;
+    height: 100%;
+  }
 }
 
 .h-shadow {
@@ -534,20 +554,20 @@ Footer
 }
 
 .join-community {
-	background-image: url("/theme-assets/homepage/join-community.png");
+  background-image: url("/theme-assets/homepage/join-community.png");
 }
 
 /**
 Various Containers
 */
 .guide-info-container {
-	@apply col-span-12 lg:col-span-3 bg-card-light text-white divide-y divide-page px-5 mb-6 md:mb-0;
+  @apply col-span-12 lg:col-span-3 bg-card-light text-white divide-y divide-page px-5 mb-6 md:mb-0;
 }
 .job-guides-container {
-	@apply col-span-12 lg:col-span-9 bg-card-light text-white py-8 md:py-14 px-8 md:px-14 lg:px-20 xl:px-28;
+  @apply col-span-12 lg:col-span-9 bg-card-light text-white py-8 md:py-14 px-8 md:px-14 lg:px-20 xl:px-28;
 }
 .table-of-contents-container {
-	@apply col-span-12 lg:order-last lg:sticky lg:col-span-3 bg-card-light text-white divide-y divide-page px-5 md:top-8 mt-8 mb-8 md:mt-0 md:mb-0;
+  @apply col-span-12 lg:order-last lg:sticky lg:col-span-3 bg-card-light text-white divide-y divide-page px-5 md:top-8 mt-8 mb-8 md:mt-0 md:mb-0;
 }
 
 /**
@@ -555,102 +575,110 @@ Markdown - Can be used to auto apply styling to tags within the .markdown class
  */
 
 .markdown {
-    @apply text-gray-light text-lg;
+  @apply text-gray-light text-lg;
 }
 
 .markdown h1 {
-    @apply text-4xl font-bold text-white flex items-center;
+  @apply text-4xl font-bold text-white flex items-center;
 }
 
 .markdown h1:after {
-    @apply bg-page ml-5;
-    flex: 1 0 0%;
-    content: '';
-    width: 100%;
-    height: 1px;
+  @apply bg-page ml-5;
+  flex: 1 0 0%;
+  content: "";
+  width: 100%;
+  height: 1px;
 }
 
 .markdown h2 {
-    @apply text-2xl font-bold text-white flex items-center uppercase;
-	letter-spacing: 2px;
+  @apply text-2xl font-bold text-white flex items-center uppercase;
+  letter-spacing: 2px;
 }
 
 .markdown h3 {
-    @apply text-xl font-bold text-white uppercase font-head;
-	letter-spacing: 2.25px;
+  @apply text-xl font-bold text-white uppercase font-head;
+  letter-spacing: 2.25px;
 }
 
 .markdown h4 {
-	@apply text-base font-bold text-white uppercase tracking-widest mb-6 font-head;
+  @apply text-base font-bold text-white uppercase tracking-widest mb-6 font-head;
 }
 
-.markdown p, h1, h2, h3, ol {
-    @apply mb-8;
+.markdown p,
+h1,
+h2,
+h3,
+ol {
+  @apply mb-8;
 }
 
 .markdown h1:not(:first-child) {
-	@apply mt-11;
+  @apply mt-11;
 }
 
 .markdown h2:not(:first-child) {
-	@apply mt-8;
+  @apply mt-8;
 }
 
 .markdown ol {
-    @apply list-decimal pl-10 space-y-2 mb-8;
+  @apply list-decimal pl-10 space-y-2 mb-8;
 }
 
 .markdown ul {
-	@apply list-disc pl-10 space-y-2 mb-8;
+  @apply list-disc pl-10 space-y-2 mb-8;
+}
+
+.markdown ul ul {
+  margin-bottom: 0;
 }
 
 .markdown a {
-	@apply text-link-orange;
+  @apply text-link-orange;
 }
 
 .markdown hr {
-	@apply mb-8;
+  @apply mb-8;
 }
 
 .markdown table > thead > tr > th:empty {
-	display:none;
+  display: none;
 }
 
 .markdown table > thead {
-	@apply text-link-orange text-left font-bold text-lg bg-card-dark;
+  @apply text-link-orange text-left font-bold text-lg bg-card-dark;
 }
 
 .markdown table > thead > tr > th {
-	@apply px-4 py-2; 
+  @apply px-4 py-2;
 }
 
 .markdown table > tbody > tr > td,
 .markdown table > thead > tr > td {
-	@apply px-4 py-2 border-table-divider-color border-r;
+  @apply px-4 py-2 border-table-divider-color border-r;
 }
 
 .markdown table > tbody > tr > td:last-of-type,
 .markdown table > thead > tr > td:last-of-type {
-	@apply border-r-0;
+  @apply border-r-0;
 }
 
 .markdown table > tbody > tr:nth-of-type(odd) {
-	@apply bg-table-light;
+  @apply bg-table-light;
 }
 
 .markdown blockquote {
-	border-left: 4px solid #ccc;
-	margin: 1.5em 10px;
-	padding: 0.5em 10px;
+  border-left: 4px solid #ccc;
+  margin: 1.5em 10px;
+  padding: 0.5em 10px;
 }
 
 .markdown blockquote p {
-	display: inline;
+  display: inline;
 }
 
 /* shortcode additions */
 .markdown .image-inline {
-	display: flex;
-	flex-wrap: wrap;
-	gap: 5px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
 }

--- a/exampleSite/content/jobs/healers/scholar/basic-guide.md
+++ b/exampleSite/content/jobs/healers/scholar/basic-guide.md
@@ -35,6 +35,13 @@ Openers are designed to do a few very important things:
 2. Get strong abilities under raid buffs. This helps to maximize damage done. More damage is always better, especially when it's free!
 3. Set up our rotation for the rest of the fight (or until a transition/extended period of downtime). This is especially important for fight specific optimizations and using the right opener may gain a use of important abilities like the Gnashing Fang combo.
 
+- A list
+- Of Items
+  - With Nested Items
+  - With hopefully no padding at the bottom
+- Final item
+  - This should have padding at the bottom though
+
 The theoretical standard opener for a full-uptime encounter is the 4th GCD No Mercy opener:
 
 At higher levels of gameplay, you can and should adjust your opener based on your group composition and the specifics of the fight.
@@ -47,7 +54,7 @@ Nullam tempus est turpis, quis sollicitudin ex lacinia quis. Vestibulum blandit 
 
 Nulla tempus, libero ullamcorper interdum gravida, tellus ante tempus lorem, vel sagittis turpis neque at mi. Suspendisse nec ex ut purus dictum condimentum. Quisque euismod consectetur neque eu euismod. Quisque condimentum quam ut tellus malesuada, sit amet vestibulum est malesuada. Phasellus elementum odio id magna aliquam viverra. Donec maximus porttitor dolor, vel feugiat sem gravida nec. Morbi vel purus a magna accumsan luctus nec ac lacus. Maecenas molestie magna sit amet nunc congue, non consequat justo ultrices. Aliquam mattis lectus at pharetra eleifend.
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam maximus elit id lectus euismod dictum. Etiam dapibus ultrices nisl, sed convallis eros scelerisque eget. Sed fermentum est vel molestie maximus. Phasellus dui lorem, consectetur nec rhoncus porttitor, mattis sed tortor. Sed congue convallis neque, ut consectetur lacus viverra vitae. Sed tincidunt, lorem vel eleifend ultricies, metus dolor lobortis lorem, nec malesuada dui orci at lacus. Suspendisse potenti. Ut velit turpis, gravida ornare viverra eget, sodales sed lorem. 
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam maximus elit id lectus euismod dictum. Etiam dapibus ultrices nisl, sed convallis eros scelerisque eget. Sed fermentum est vel molestie maximus. Phasellus dui lorem, consectetur nec rhoncus porttitor, mattis sed tortor. Sed congue convallis neque, ut consectetur lacus viverra vitae. Sed tincidunt, lorem vel eleifend ultricies, metus dolor lobortis lorem, nec malesuada dui orci at lacus. Suspendisse potenti. Ut velit turpis, gravida ornare viverra eget, sodales sed lorem.
 
 ## Other 2
 
@@ -55,7 +62,7 @@ Nullam tempus est turpis, quis sollicitudin ex lacinia quis. Vestibulum blandit 
 
 Nulla tempus, libero ullamcorper interdum gravida, tellus ante tempus lorem, vel sagittis turpis neque at mi. Suspendisse nec ex ut purus dictum condimentum. Quisque euismod consectetur neque eu euismod. Quisque condimentum quam ut tellus malesuada, sit amet vestibulum est malesuada. Phasellus elementum odio id magna aliquam viverra. Donec maximus porttitor dolor, vel feugiat sem gravida nec. Morbi vel purus a magna accumsan luctus nec ac lacus. Maecenas molestie magna sit amet nunc congue, non consequat justo ultrices. Aliquam mattis lectus at pharetra eleifend.
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam maximus elit id lectus euismod dictum. Etiam dapibus ultrices nisl, sed convallis eros scelerisque eget. Sed fermentum est vel molestie maximus. Phasellus dui lorem, consectetur nec rhoncus porttitor, mattis sed tortor. Sed congue convallis neque, ut consectetur lacus viverra vitae. Sed tincidunt, lorem vel eleifend ultricies, metus dolor lobortis lorem, nec malesuada dui orci at lacus. Suspendisse potenti. Ut velit turpis, gravida ornare viverra eget, sodales sed lorem. 
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam maximus elit id lectus euismod dictum. Etiam dapibus ultrices nisl, sed convallis eros scelerisque eget. Sed fermentum est vel molestie maximus. Phasellus dui lorem, consectetur nec rhoncus porttitor, mattis sed tortor. Sed congue convallis neque, ut consectetur lacus viverra vitae. Sed tincidunt, lorem vel eleifend ultricies, metus dolor lobortis lorem, nec malesuada dui orci at lacus. Suspendisse potenti. Ut velit turpis, gravida ornare viverra eget, sodales sed lorem.
 
 ## More Other
 
@@ -63,9 +70,10 @@ Nullam tempus est turpis, quis sollicitudin ex lacinia quis. Vestibulum blandit 
 
 Nulla tempus, libero ullamcorper interdum gravida, tellus ante tempus lorem, vel sagittis turpis neque at mi. Suspendisse nec ex ut purus dictum condimentum. Quisque euismod consectetur neque eu euismod. Quisque condimentum quam ut tellus malesuada, sit amet vestibulum est malesuada. Phasellus elementum odio id magna aliquam viverra. Donec maximus porttitor dolor, vel feugiat sem gravida nec. Morbi vel purus a magna accumsan luctus nec ac lacus. Maecenas molestie magna sit amet nunc congue, non consequat justo ultrices. Aliquam mattis lectus at pharetra eleifend.
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam maximus elit id lectus euismod dictum. Etiam dapibus ultrices nisl, sed convallis eros scelerisque eget. Sed fermentum est vel molestie maximus. Phasellus dui lorem, consectetur nec rhoncus porttitor, mattis sed tortor. Sed congue convallis neque, ut consectetur lacus viverra vitae. Sed tincidunt, lorem vel eleifend ultricies, metus dolor lobortis lorem, nec malesuada dui orci at lacus. Suspendisse potenti. Ut velit turpis, gravida ornare viverra eget, sodales sed lorem. 
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam maximus elit id lectus euismod dictum. Etiam dapibus ultrices nisl, sed convallis eros scelerisque eget. Sed fermentum est vel molestie maximus. Phasellus dui lorem, consectetur nec rhoncus porttitor, mattis sed tortor. Sed congue convallis neque, ut consectetur lacus viverra vitae. Sed tincidunt, lorem vel eleifend ultricies, metus dolor lobortis lorem, nec malesuada dui orci at lacus. Suspendisse potenti. Ut velit turpis, gravida ornare viverra eget, sodales sed lorem.
 
 ## Some Cool SCH Code
+
 {{< codeblock >}}
 Line 1 of my code
 Line 2 of my code (this line is really long; on mobile it should generate an x-axis scrollbar)

--- a/exampleSite/static/admin/index.html
+++ b/exampleSite/static/admin/index.html
@@ -20,6 +20,7 @@
     <script src="https://unpkg.com/netlify-cms@^2.0.0/dist/netlify-cms.js"></script>
     <!-- Include the script for previewing Hugo shortcodes -->
     <script src="https://sharadcodes.github.io/hugo-shortcodes-netlify-cms/dist/hugo_shortcodes_netlify_cms.js"></script>
+    <script src="/theme-assets/editor/job-preview.js"></script>
     <script>
       DarkReader.enable(); // Enable darkreader
       CMS.registerPreviewStyle("/css/main.css"); // Register preview styles in Netlify
@@ -38,6 +39,7 @@
         },
       });
       CMS.registerPreviewTemplate("landing", LandingPreviewTemplate);
+      CMS.registerPreviewTemplate("leveling-guide", GenericJobGuide);
     </script>
   </body>
 </html>

--- a/exampleSite/static/admin/index.html
+++ b/exampleSite/static/admin/index.html
@@ -4,11 +4,40 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Content Manager</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Kumbh+Sans:wght@100;700&family=Roboto:ital,wght@0,100;0,400;0,700;1,100;1,400;1,700&display=swap"
+      rel="stylesheet"
+    />
     <!-- Include the script that enables Netlify Identity on this page. -->
     <script src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>
+    <!-- Darkreader -->
+    <script src="https://cdn.jsdelivr.net/npm/darkreader@4.9.27/darkreader.min.js"></script>
   </head>
   <body>
     <!-- Include the script that builds the page and powers Netlify CMS -->
     <script src="https://unpkg.com/netlify-cms@^2.0.0/dist/netlify-cms.js"></script>
+    <!-- Include the script for previewing Hugo shortcodes -->
+    <script src="https://sharadcodes.github.io/hugo-shortcodes-netlify-cms/dist/hugo_shortcodes_netlify_cms.js"></script>
+    <script>
+      DarkReader.enable(); // Enable darkreader
+      CMS.registerPreviewStyle("/css/main.css"); // Register preview styles in Netlify
+
+      let LandingPreviewTemplate = createClass({
+        render: function () {
+          return h(
+            "div",
+            { class: "job-guides-container" },
+            h(
+              "div",
+              { class: "markdown max-w-none" },
+              this.props.widgetFor("body")
+            )
+          );
+        },
+      });
+      CMS.registerPreviewTemplate("landing", LandingPreviewTemplate);
+    </script>
   </body>
 </html>

--- a/exampleSite/static/admin/index.html
+++ b/exampleSite/static/admin/index.html
@@ -40,6 +40,9 @@
       });
       CMS.registerPreviewTemplate("landing", LandingPreviewTemplate);
       CMS.registerPreviewTemplate("leveling-guide", GenericJobGuide);
+      CMS.registerPreviewTemplate("basic-guide", GenericJobGuide);
+      CMS.registerPreviewTemplate("skills-overview", GenericJobGuide);
+      CMS.registerPreviewTemplate("openers", GenericJobGuide);
     </script>
   </body>
 </html>

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,20 +1,27 @@
 <!DOCTYPE html>
 <html lang="en">
-    <head>
-        {{- partial "head.html" . -}}
-    </head>
-    <body>
-        {{ $title := .Title }}
-        {{ if eq $title "Home"}}
-        <header class="bg-center bg-cover relative z-10 h-64 md:h-96 mt-10 lg:mt-0"></header>
-          {{- partial "header_home.html" . -}}
-        {{ else }}
-          {{- partial "header.html" . -}}
-        {{ end}}
-        <div id="content" class="z-20">
-        {{- block "main" . }}{{- end }}
-        </div>
-        {{ partial "image-modal.html" . }}
-        {{- partial "footer.html" . -}}
-    </body>
+  <head>
+    {{- partial "head.html" . -}}
+  </head>
+  <body>
+    {{ $title := .Title }}
+    {{ if eq $title "Home" }}
+      <header
+        class="bg-center bg-cover relative z-10 h-64 md:h-96 mt-10 lg:mt-0"
+      ></header>
+      {{- partial "header_home.html" . -}}
+    {{ else }}
+      {{- partial "header.html" . -}}
+    {{ end }}
+    <div id="content" class="z-20">
+      {{- block "main" . }}{{- end }}
+    </div>
+    {{- partial "footer.html" . -}}
+    {{ $headerJs := resources.Get "js/header.js" }}
+    {{ $navJs := resources.Get "js/nav.js" }}
+
+    <script type="text/javascript" src="{{ $headerJs.RelPermalink }}" defer></script>
+    <script type="text/javascript" src="{{ $navJs.RelPermalink }}" defer></script>
+    {{ partial "image-modal.html" . }}
+  </body>
 </html>

--- a/layouts/partials/cards/default.html
+++ b/layouts/partials/cards/default.html
@@ -1,22 +1,21 @@
 {{ $borderClass := default "gray-600" .role }}
-
 <div>
-	{{ with .image }}
-	<div>
-		<img class="w-full" src="{{ . }}" />
-	</div>
-	{{ end }}
-	<div class="card card-{{ $borderClass }} space-y-3">
-    {{ if isset . "name" }}
-    <div class="border-b border-card-dark pb-8">
-      {{ partial "cards/_header.html" . }}
+  {{ with .image }}
+    <div>
+      <img class="w-full" src="{{ . }}" />
     </div>
+  {{ end }}
+  <div class="card card-{{ $borderClass }} space-y-3">
+    {{ if isset . "name" }}
+      <div class="border-b border-card-dark pb-8">
+        {{ partial "cards/_header.html" . }}
+      </div>
     {{ end }}
     <div>
-      {{ .text }}
+      {{ .text | markdownify }}
     </div>
     {{ if isset . "readMoreLink" }}
       {{ partial "cards/_footer.html" . }}
     {{ end }}
-	</div>
+  </div>
 </div>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -10,31 +10,35 @@
   <meta name="keywords" content="{{ delimit .Params.tags ", " }}" />
 {{ end }}
 
-<link rel="shortcut icon" type="image/ico" href="/favicon.ico">
-<link rel="shortcut icon" sizes="192x192" href="/android-chrome-192x192.png">
-<link rel="shortcut icon" sizes="512x512" href="/android-chrome-512x512.png">
-<link rel="apple-touch-icon" href="/apple-touch-icon.png">
-<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+
+<link rel="shortcut icon" type="image/ico" href="/favicon.ico" />
+<link rel="shortcut icon" sizes="192x192" href="/android-chrome-192x192.png" />
+<link rel="shortcut icon" sizes="512x512" href="/android-chrome-512x512.png" />
+<link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
+<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
 {{- template "_internal/schema.html" . }}
 {{- template "_internal/opengraph.html" . }}
-<link rel="manifest" href="/site.webmanifest">
-<link rel="mask-icon" href="/safari-pinned-tab.svg" color="#ff9900">
-<meta name="msapplication-TileColor" content="#ffffff">
-<meta name="theme-color" content="#ffffff">
-<title>{{ .Site.Title }}{{ with .Title }} | {{ . }}{{ end }}</title>
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Kumbh+Sans:wght@100;700&family=Roboto:ital,wght@0,100;0,400;0,700;1,100;1,400;1,700&display=swap" rel="stylesheet">
+<link rel="manifest" href="/site.webmanifest" />
+<link rel="mask-icon" href="/safari-pinned-tab.svg" color="#ff9900" />
+<meta name="msapplication-TileColor" content="#ffffff" />
+<meta name="theme-color" content="#ffffff" />
+<title>{{ .Site.Title }}{{ with .Title }}| {{ . }}{{ end }}</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link
+  href="https://fonts.googleapis.com/css2?family=Kumbh+Sans:wght@100;700&family=Roboto:ital,wght@0,100;0,400;0,700;1,100;1,400;1,700&display=swap"
+  rel="stylesheet"
+/>
 {{ $styles := resources.Get "css/main.css" | postCSS }}
-{{ $headerJs := resources.Get "js/header.js" }}
-{{ $navJs := resources.Get "js/nav.js" }}
-<script type="text/javascript" src="{{ $headerJs.RelPermalink }}" defer></script>
-<script type="text/javascript" src="{{ $navJs.RelPermalink }}" defer></script>
 {{ if .Site.IsServer }}
   <link rel="stylesheet" href="{{ $styles.RelPermalink }}" />
 {{ else }}
   {{ $styles := $styles | minify | fingerprint | resources.PostProcess }}
-  <link rel="stylesheet" href="{{ $styles.RelPermalink }}" integrity="{{ $styles.Data.Integrity }}" />
+  <link
+    rel="stylesheet"
+    href="{{ $styles.RelPermalink }}"
+    integrity="{{ $styles.Data.Integrity }}"
+  />
 {{ end }}

--- a/static/theme-assets/editor/job-preview.js
+++ b/static/theme-assets/editor/job-preview.js
@@ -16,6 +16,7 @@ const renderGuideContainer = function (body, ...children) {
 };
 
 const renderAuthorList = function (authors) {
+  let authorList = authors ?? [];
   return h(
     "div",
     { class: "job-guides-container markdown" },
@@ -23,7 +24,7 @@ const renderAuthorList = function (authors) {
     h(
       "ul",
       {},
-      authors.map(function (author) {
+      authorList.map(function (author) {
         return h("li", {}, author);
       })
     )

--- a/static/theme-assets/editor/job-preview.js
+++ b/static/theme-assets/editor/job-preview.js
@@ -1,9 +1,40 @@
 let GenericJobGuide = createClass({
   render: function () {
+    console.log(
+      "perhaps author list?",
+      this.props.entry.getIn(["data", "authors"]).map(function (author, index) {
+        console.log("individual author:", author);
+      })
+    );
     return h(
       "div",
-      { class: "job-guides-container" },
-      h("div", { class: "markdown max-w-none" }, this.props.widgetFor("body"))
+      { class: "space-y-16" },
+      h(
+        "div",
+        { class: "responsive-container" },
+        h(
+          "div",
+          { class: "job-guides-container" },
+          h(
+            "div",
+            { class: "markdown max-w-none" },
+            this.props.widgetFor("body")
+          )
+        ),
+        h("hr", {}),
+        h(
+          "div",
+          { class: "job-guides-container markdown" },
+          h("h1", {}, "Authors"),
+          h(
+            "ul",
+            {},
+            this.props.entry.getIn(["data", "authors"]).map(function (author) {
+              return h("li", {}, author);
+            })
+          )
+        )
+      )
     );
   },
 });

--- a/static/theme-assets/editor/job-preview.js
+++ b/static/theme-assets/editor/job-preview.js
@@ -1,11 +1,5 @@
 let GenericJobGuide = createClass({
   render: function () {
-    console.log(
-      "perhaps author list?",
-      this.props.entry.getIn(["data", "authors"]).map(function (author, index) {
-        console.log("individual author:", author);
-      })
-    );
     return h(
       "div",
       { class: "space-y-16" },

--- a/static/theme-assets/editor/job-preview.js
+++ b/static/theme-assets/editor/job-preview.js
@@ -1,34 +1,43 @@
-let GenericJobGuide = createClass({
-  render: function () {
-    return h(
+const renderGuideContainer = function (body, ...children) {
+  return h(
+    "div",
+    { class: "space-y-16" },
+    h(
       "div",
-      { class: "space-y-16" },
+      { class: "responsive-container" },
       h(
         "div",
-        { class: "responsive-container" },
-        h(
-          "div",
-          { class: "job-guides-container" },
-          h(
-            "div",
-            { class: "markdown max-w-none" },
-            this.props.widgetFor("body")
-          )
-        ),
-        h("hr", {}),
-        h(
-          "div",
-          { class: "job-guides-container markdown" },
-          h("h1", {}, "Authors"),
-          h(
-            "ul",
-            {},
-            this.props.entry.getIn(["data", "authors"]).map(function (author) {
-              return h("li", {}, author);
-            })
-          )
-        )
-      )
+        { class: "job-guides-container" },
+        h("div", { class: "markdown max-w-none" }, body)
+      ),
+      ...children
+    )
+  );
+};
+
+const renderAuthorList = function (authors) {
+  return h(
+    "div",
+    { class: "job-guides-container markdown" },
+    h("h1", {}, "Authors"),
+    h(
+      "ul",
+      {},
+      authors.map(function (author) {
+        return h("li", {}, author);
+      })
+    )
+  );
+};
+
+let GenericJobGuide = createClass({
+  render: function () {
+    const authors = this.props.entry.getIn(["data", "authors"]);
+
+    return renderGuideContainer(
+      this.props.widgetFor("body"),
+      h("hr", {}),
+      renderAuthorList(authors)
     );
   },
 });

--- a/static/theme-assets/editor/job-preview.js
+++ b/static/theme-assets/editor/job-preview.js
@@ -1,0 +1,9 @@
+let GenericJobGuide = createClass({
+  render: function () {
+    return h(
+      "div",
+      { class: "job-guides-container" },
+      h("div", { class: "markdown max-w-none" }, this.props.widgetFor("body"))
+    );
+  },
+});


### PR DESCRIPTION
PostCSS is back on the menu.

Though my superpower of "[reading the documentation](https://www.netlifycms.org/docs/customization/#registerpreviewtemplate)", I enabled "accurate" previews of content in the editor:

<img width="2056" alt="Screen Shot 2022-06-24 at 10 56 14 PM" src="https://user-images.githubusercontent.com/83298827/175757212-4f526209-0f40-45c7-8817-474ba03099c8.png">

As you can see from the single file modified, this allows you to completely reuse main style CSS and have the preview be representative of something that will land on the production site, and it will track correctly as the theme updates.

What I need from the reviewer:
1. List of page types to prioritize throughout the lifetime of this PR
2. Additional data to represent in the preview (header image, etc)
3. Feedback on where to split out all the previews to (I refuse to let them live in a script tag long-term)