### PR TITLE
Fix for .URL support removal

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -45,7 +45,7 @@
         <li class="flex flex-wrap">
           <a
             href="{{ .URL }}"
-            class="w-11/12 block text-lg py-3 text-white font-semibold {{ if eq $current.URL .URL }}text-link-orange{{ end }}" title="{{ .Title }}"
+            class="w-11/12 block text-lg py-3 text-white font-semibold {{ if eq $current.Permalink .URL }}text-link-orange{{ end }}" title="{{ .Title }}"
           >
             {{ .Name }}
           </a>

--- a/layouts/partials/header_home.html
+++ b/layouts/partials/header_home.html
@@ -26,7 +26,7 @@
         {{ range $list }}
         <li class="flex flex-wrap">
           <a href="{{ .URL }}"
-            class="w-11/12 text-lg block py-3 text-white font-semibold {{ if eq $current.URL .URL }}text-link-orange{{ end }}"
+            class="w-11/12 text-lg block py-3 text-white font-semibold {{ if eq $current.Permalink .URL }}text-link-orange{{ end }}"
             title="{{ .Title }}">
             {{ .Name }}
           </a>


### PR DESCRIPTION
Addresses #276 by using .Permalink instead of .URL in both header.html and header_home.html.

Note, the uses of .URL still in these files are valid because they're context sensitive and don't run into the same issue.

Only uses of $current.URL needed to be changed.