### PR TITLE
Feat/hugo workflow pinning

### DIFF
--- a/.github/workflows/pr-creation.yml
+++ b/.github/workflows/pr-creation.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: '0.86.1'
+          hugo-version: '0.101.0'
           extended: true
 
       - name: Setup node

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Glam is a theme for The Balance website put together by the wonderful FFXIV comm
   1. Choose the latest LTS release listed.
   2. Accept all default options.
 * [hugo](https://github.com/gohugoio/hugo/releases) (Optionally, you can install `hugo` via a package manager if desired.)
-  1. Choose hugo__extended_X.XXX.X_Windows-64bit.zip where the X's are the current version.
+  1. Choose hugo__extended_X.XXX.X_Windows-64bit.zip where the X's are the current version (Latest tested with `0.101.0`).
   2. Extract the .zip to a location of your choosing (Documents is reasonable choice).
   3. Open the extracted folder and right click on `hugo.exe` and select properties.
   4. Check the `Unblock` box near the bottom and press `Ok`.


### PR DESCRIPTION
It's your least favorite perpetually independent AhSotDC, back again with small fixes!

Since #276 is fixed, it seemed right to bump the version in the workflow (and once the theme is updated in `balance-static`, you need to bump the version there as well as part of whatever PR y'all decide to do for that).