### PR TITLE
Fixes an issue with disappearing text

### DIFF
--- a/layouts/partials/cards/default.html
+++ b/layouts/partials/cards/default.html
@@ -12,7 +12,7 @@
       </div>
     {{ end }}
     <div>
-      {{ .text | markdownify }}
+      {{ .text }}
     </div>
     {{ if isset . "readMoreLink" }}
       {{ partial "cards/_footer.html" . }}


### PR DESCRIPTION
The default card template used markdownify on the job descriptions, and this is now causing the text to not appear at all. This PR removes the use of markdownify in the default card template. 