### PR TITLE
Stop GHA cluttering up things when it isn't needed

### DIFF
--- a/.github/workflows/pr-creation.yml
+++ b/.github/workflows/pr-creation.yml
@@ -3,6 +3,10 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - 'assets/**.css'
+      - 'layouts/_default/**'
+      - 'partials/*.html'
 
 jobs:
   pr-creation:


### PR DESCRIPTION
What is says on the tin. Related to #285, this is a non-exhaustive list of things that only affect the front page. Another step would be to tie certain layouts to certain screenshot generation workflows, but that's a PR for another time – my goal right now is to stop the annoying workflow when we aren't changing anything.