### PR TITLE
make glam work as a development package and as an included theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Glam is a theme for The Balance website put together by the wonderful FFXIV comm
 5. Run `yarn` to setup the necessary environment.
 ### How to run the project
 1. Navigate to your project folder in a command prompt or Powershell window.
-2. Run `yarn start`.
+2. Run `yarn start:dev`.
 3. Navigate to `localhost:1313` in a web browser to view the local version of the website.
   
 
@@ -50,15 +50,10 @@ export PATH=$PATH:${PWD}/node_modules/.bin
 yarn
 
 # Run the servers
-yarn start:static
+yarn start:dev
 
 # Server starts by default on `localhost:1313`
 ```
-
-## Using the editor locally
-
-First run the static site server with `yarn start:static`, then run `yarn start:admin` and navigate to `http://localhost:1313/admin`.
-Alternatively, `yarn start` will start both servers.
 
 # Configuration
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "start": "concurrently --kill-others-on-fail --names static,admin \"yarn start:static\" \"yarn start:admin\"",
     "start:dev": "cross-env GIT_REPO_DIRECTORY=exampleSite concurrently --kill-others-on-fail --names static,admin \"yarn start:static:dev\" \"yarn start:admin\"",
-    "start:static": "hugo server -s exampleSite/ --themesDir=../.. --disableFastRender",
+    "start:static": "hugo server --disableFastRender",
     "start:static:dev": "hugo server -s exampleSite/ --themesDir=../.. --disableFastRender",
     "start:admin": "node_modules/.bin/netlify-cms-proxy-server"
   }

--- a/package.json
+++ b/package.json
@@ -23,8 +23,9 @@
   },
   "scripts": {
     "start": "concurrently --kill-others-on-fail --names static,admin \"yarn start:static\" \"yarn start:admin\"",
-    "start:dev": "cross-env GIT_REPO_DIRECTORY=exampleSite concurrently --kill-others-on-fail --names static,admin \"yarn start:static\" \"yarn start:admin\"",
+    "start:dev": "cross-env GIT_REPO_DIRECTORY=exampleSite concurrently --kill-others-on-fail --names static,admin \"yarn start:static:dev\" \"yarn start:admin\"",
     "start:static": "hugo server -s exampleSite/ --themesDir=../.. --disableFastRender",
+    "start:static:dev": "hugo server -s exampleSite/ --themesDir=../.. --disableFastRender",
     "start:admin": "node_modules/.bin/netlify-cms-proxy-server"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   },
   "scripts": {
     "start": "concurrently --kill-others-on-fail --names static,admin \"yarn start:static\" \"yarn start:admin\"",
+    "start:dev": "cross-env GIT_REPO_DIRECTORY=exampleSite concurrently --kill-others-on-fail --names static,admin \"yarn start:static\" \"yarn start:admin\"",
     "start:static": "hugo server -s exampleSite/ --themesDir=../.. --disableFastRender",
-    "start:admin": "cross-env GIT_REPO_DIRECTORY=exampleSite node_modules/.bin/netlify-cms-proxy-server"
+    "start:admin": "node_modules/.bin/netlify-cms-proxy-server"
   }
 }


### PR DESCRIPTION
Basically, `yarn start:dev` will start work with the theme in `exampleSite`, and `yarn start` will work with anything where glam is included as a theme.