### PR TITLE
Generate config dynamically

### DIFF
--- a/exampleSite/content/jobs/healers/scholar/_index.md
+++ b/exampleSite/content/jobs/healers/scholar/_index.md
@@ -6,7 +6,7 @@ menu:
     identifier: scholar
     name: Scholar
     parent: healers
-seo-description: The landing page for Scholars
+description: The landing page for scholars, where all the cool kids hang out
 tags:
   - FFXIV
 ---

--- a/exampleSite/content/jobs/healers/scholar/_index.md
+++ b/exampleSite/content/jobs/healers/scholar/_index.md
@@ -1,10 +1,13 @@
 ---
+title: Scholar
+job_name: scholar
 menu:
   main:
     identifier: scholar
     name: Scholar
     parent: healers
-title: Scholar
-job_name: scholar
+seo-description: The landing page for Scholars
+tags:
+  - FFXIV
 ---
 Scholar features proactive gameplay alongside pet management. With a multitude of mitigation tools via shields and Sacred Soil, Scholar benefits the most from planning and resource management in order to maximize their effectiveness. The Scholar's pet fairy contributes a large portion of the healing which will enable you to keep up your damage while the pet keeps everyone healthy.

--- a/exampleSite/data/seo/tags/ffxiv-1.json
+++ b/exampleSite/data/seo/tags/ffxiv-1.json
@@ -1,0 +1,4 @@
+{
+  "description": "Have you heard of the critically acclaimed MMORPG Final Fantasy XIV? With an expanded free trial which you can play through the entirety of A Realm Reborn and the award winning Heavensward expansion up to level 60 for free with no restrictions on playtime.",
+  "tag": "FFXIV"
+}

--- a/exampleSite/data/seo/tags/ffxiv-1.json
+++ b/exampleSite/data/seo/tags/ffxiv-1.json
@@ -1,4 +1,0 @@
-{
-  "description": "Have you heard of the critically acclaimed MMORPG Final Fantasy XIV? With an expanded free trial which you can play through the entirety of A Realm Reborn and the award winning Heavensward expansion up to level 60 for free with no restrictions on playtime.",
-  "tag": "FFXIV"
-}

--- a/exampleSite/data/seo/tags/ffxiv.json
+++ b/exampleSite/data/seo/tags/ffxiv.json
@@ -1,0 +1,4 @@
+{
+  "tag": "FFXIV",
+  "description": "Have you heard of the critically acclaimed MMORPG Final Fantasy XIV? With an expanded free trial which you can play through the entirety of A Realm Reborn and the award winning Heavensward expansion up to level 60 for free with no restrictions on playtime."
+}

--- a/exampleSite/static/admin/dev.yml
+++ b/exampleSite/static/admin/dev.yml
@@ -3122,7 +3122,7 @@ collections:
       name: menu
       required: false
       widget: object
-    file: content/jobs/tanks/scholar/_index.md
+    file: content/jobs/healers/scholar/_index.md
     label: Landing page
     name: landing
   - fields:
@@ -3692,7 +3692,7 @@ collections:
       name: menu
       required: false
       widget: object
-    file: content/jobs/tanks/white-mage/_index.md
+    file: content/jobs/healers/white-mage/_index.md
     label: Landing page
     name: landing
   - fields:
@@ -4262,7 +4262,7 @@ collections:
       name: menu
       required: false
       widget: object
-    file: content/jobs/tanks/astrologian/_index.md
+    file: content/jobs/healers/astrologian/_index.md
     label: Landing page
     name: landing
   - fields:
@@ -4832,7 +4832,7 @@ collections:
       name: menu
       required: false
       widget: object
-    file: content/jobs/tanks/sage/_index.md
+    file: content/jobs/healers/sage/_index.md
     label: Landing page
     name: landing
   - fields:
@@ -5402,7 +5402,7 @@ collections:
       name: menu
       required: false
       widget: object
-    file: content/jobs/tanks/monk/_index.md
+    file: content/jobs/melee/monk/_index.md
     label: Landing page
     name: landing
   - fields:
@@ -5972,7 +5972,7 @@ collections:
       name: menu
       required: false
       widget: object
-    file: content/jobs/tanks/dragoon/_index.md
+    file: content/jobs/melee/dragoon/_index.md
     label: Landing page
     name: landing
   - fields:
@@ -6542,7 +6542,7 @@ collections:
       name: menu
       required: false
       widget: object
-    file: content/jobs/tanks/ninja/_index.md
+    file: content/jobs/melee/ninja/_index.md
     label: Landing page
     name: landing
   - fields:
@@ -7112,7 +7112,7 @@ collections:
       name: menu
       required: false
       widget: object
-    file: content/jobs/tanks/samurai/_index.md
+    file: content/jobs/melee/samurai/_index.md
     label: Landing page
     name: landing
   - fields:
@@ -7682,7 +7682,7 @@ collections:
       name: menu
       required: false
       widget: object
-    file: content/jobs/tanks/reaper/_index.md
+    file: content/jobs/melee/reaper/_index.md
     label: Landing page
     name: landing
   - fields:
@@ -8252,7 +8252,7 @@ collections:
       name: menu
       required: false
       widget: object
-    file: content/jobs/tanks/bard/_index.md
+    file: content/jobs/ranged/bard/_index.md
     label: Landing page
     name: landing
   - fields:
@@ -8822,7 +8822,7 @@ collections:
       name: menu
       required: false
       widget: object
-    file: content/jobs/tanks/machinist/_index.md
+    file: content/jobs/ranged/machinist/_index.md
     label: Landing page
     name: landing
   - fields:
@@ -9392,7 +9392,7 @@ collections:
       name: menu
       required: false
       widget: object
-    file: content/jobs/tanks/dancer/_index.md
+    file: content/jobs/ranged/dancer/_index.md
     label: Landing page
     name: landing
   - fields:
@@ -9962,7 +9962,7 @@ collections:
       name: menu
       required: false
       widget: object
-    file: content/jobs/tanks/black-mage/_index.md
+    file: content/jobs/casters/black-mage/_index.md
     label: Landing page
     name: landing
   - fields:
@@ -10532,7 +10532,7 @@ collections:
       name: menu
       required: false
       widget: object
-    file: content/jobs/tanks/red-mage/_index.md
+    file: content/jobs/casters/red-mage/_index.md
     label: Landing page
     name: landing
   - fields:
@@ -11102,7 +11102,7 @@ collections:
       name: menu
       required: false
       widget: object
-    file: content/jobs/tanks/summoner/_index.md
+    file: content/jobs/casters/summoner/_index.md
     label: Landing page
     name: landing
   - fields:

--- a/exampleSite/static/admin/dev.yml
+++ b/exampleSite/static/admin/dev.yml
@@ -556,7 +556,7 @@ collections:
     summary: '{{fields.date}}: {{fields.message}}'
     widget: list
   - label: SEO Description
-    name: seo-description
+    name: description
     required: false
     widget: string
   - collection: seo-tags
@@ -697,7 +697,7 @@ collections:
     summary: '{{fields.date}}: {{fields.message}}'
     widget: list
   - label: SEO Description
-    name: seo-description
+    name: description
     required: false
     widget: string
   - collection: seo-tags
@@ -838,7 +838,7 @@ collections:
     summary: '{{fields.date}}: {{fields.message}}'
     widget: list
   - label: SEO Description
-    name: seo-description
+    name: description
     required: false
     widget: string
   - collection: seo-tags
@@ -902,7 +902,7 @@ collections:
       required: false
       widget: object
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -972,7 +972,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -1042,7 +1042,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -1112,7 +1112,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -1182,7 +1182,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -1249,7 +1249,7 @@ collections:
       value_field: username
       widget: relation
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -1319,7 +1319,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -1471,7 +1471,7 @@ collections:
       value_field: username
       widget: relation
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -1533,7 +1533,7 @@ collections:
       value_field: username
       widget: relation
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -1598,7 +1598,7 @@ collections:
       required: false
       widget: object
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -1668,7 +1668,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -1738,7 +1738,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -1808,7 +1808,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -1878,7 +1878,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -1945,7 +1945,7 @@ collections:
       value_field: username
       widget: relation
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -2015,7 +2015,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -2167,7 +2167,7 @@ collections:
       value_field: username
       widget: relation
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -2229,7 +2229,7 @@ collections:
       value_field: username
       widget: relation
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -2294,7 +2294,7 @@ collections:
       required: false
       widget: object
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -2364,7 +2364,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -2434,7 +2434,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -2504,7 +2504,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -2574,7 +2574,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -2641,7 +2641,7 @@ collections:
       value_field: username
       widget: relation
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -2711,7 +2711,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -2863,7 +2863,7 @@ collections:
       value_field: username
       widget: relation
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -2925,7 +2925,7 @@ collections:
       value_field: username
       widget: relation
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -2990,7 +2990,7 @@ collections:
       required: false
       widget: object
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -3060,7 +3060,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -3130,7 +3130,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -3200,7 +3200,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -3270,7 +3270,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -3337,7 +3337,7 @@ collections:
       value_field: username
       widget: relation
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -3407,7 +3407,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -3559,7 +3559,7 @@ collections:
       value_field: username
       widget: relation
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -3621,7 +3621,7 @@ collections:
       value_field: username
       widget: relation
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -3686,7 +3686,7 @@ collections:
       required: false
       widget: object
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -3756,7 +3756,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -3826,7 +3826,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -3896,7 +3896,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -3966,7 +3966,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -4033,7 +4033,7 @@ collections:
       value_field: username
       widget: relation
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -4103,7 +4103,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -4255,7 +4255,7 @@ collections:
       value_field: username
       widget: relation
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -4317,7 +4317,7 @@ collections:
       value_field: username
       widget: relation
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -4382,7 +4382,7 @@ collections:
       required: false
       widget: object
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -4452,7 +4452,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -4522,7 +4522,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -4592,7 +4592,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -4662,7 +4662,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -4729,7 +4729,7 @@ collections:
       value_field: username
       widget: relation
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -4799,7 +4799,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -4951,7 +4951,7 @@ collections:
       value_field: username
       widget: relation
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -5013,7 +5013,7 @@ collections:
       value_field: username
       widget: relation
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -5078,7 +5078,7 @@ collections:
       required: false
       widget: object
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -5148,7 +5148,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -5218,7 +5218,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -5288,7 +5288,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -5358,7 +5358,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -5425,7 +5425,7 @@ collections:
       value_field: username
       widget: relation
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -5495,7 +5495,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -5647,7 +5647,7 @@ collections:
       value_field: username
       widget: relation
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -5709,7 +5709,7 @@ collections:
       value_field: username
       widget: relation
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -5774,7 +5774,7 @@ collections:
       required: false
       widget: object
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -5844,7 +5844,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -5914,7 +5914,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -5984,7 +5984,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -6054,7 +6054,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -6121,7 +6121,7 @@ collections:
       value_field: username
       widget: relation
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -6191,7 +6191,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -6343,7 +6343,7 @@ collections:
       value_field: username
       widget: relation
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -6405,7 +6405,7 @@ collections:
       value_field: username
       widget: relation
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -6470,7 +6470,7 @@ collections:
       required: false
       widget: object
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -6540,7 +6540,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -6610,7 +6610,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -6680,7 +6680,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -6750,7 +6750,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -6817,7 +6817,7 @@ collections:
       value_field: username
       widget: relation
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -6887,7 +6887,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -7039,7 +7039,7 @@ collections:
       value_field: username
       widget: relation
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -7101,7 +7101,7 @@ collections:
       value_field: username
       widget: relation
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -7166,7 +7166,7 @@ collections:
       required: false
       widget: object
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -7236,7 +7236,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -7306,7 +7306,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -7376,7 +7376,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -7446,7 +7446,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -7513,7 +7513,7 @@ collections:
       value_field: username
       widget: relation
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -7583,7 +7583,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -7735,7 +7735,7 @@ collections:
       value_field: username
       widget: relation
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -7797,7 +7797,7 @@ collections:
       value_field: username
       widget: relation
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -7862,7 +7862,7 @@ collections:
       required: false
       widget: object
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -7932,7 +7932,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -8002,7 +8002,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -8072,7 +8072,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -8142,7 +8142,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -8209,7 +8209,7 @@ collections:
       value_field: username
       widget: relation
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -8279,7 +8279,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -8431,7 +8431,7 @@ collections:
       value_field: username
       widget: relation
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -8493,7 +8493,7 @@ collections:
       value_field: username
       widget: relation
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -8558,7 +8558,7 @@ collections:
       required: false
       widget: object
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -8628,7 +8628,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -8698,7 +8698,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -8768,7 +8768,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -8838,7 +8838,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -8905,7 +8905,7 @@ collections:
       value_field: username
       widget: relation
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -8975,7 +8975,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -9127,7 +9127,7 @@ collections:
       value_field: username
       widget: relation
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -9189,7 +9189,7 @@ collections:
       value_field: username
       widget: relation
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -9254,7 +9254,7 @@ collections:
       required: false
       widget: object
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -9324,7 +9324,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -9394,7 +9394,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -9464,7 +9464,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -9534,7 +9534,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -9601,7 +9601,7 @@ collections:
       value_field: username
       widget: relation
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -9671,7 +9671,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -9823,7 +9823,7 @@ collections:
       value_field: username
       widget: relation
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -9885,7 +9885,7 @@ collections:
       value_field: username
       widget: relation
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -9950,7 +9950,7 @@ collections:
       required: false
       widget: object
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -10020,7 +10020,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -10090,7 +10090,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -10160,7 +10160,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -10230,7 +10230,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -10297,7 +10297,7 @@ collections:
       value_field: username
       widget: relation
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -10367,7 +10367,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -10519,7 +10519,7 @@ collections:
       value_field: username
       widget: relation
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -10581,7 +10581,7 @@ collections:
       value_field: username
       widget: relation
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -10646,7 +10646,7 @@ collections:
       required: false
       widget: object
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -10716,7 +10716,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -10786,7 +10786,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -10856,7 +10856,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -10926,7 +10926,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -10993,7 +10993,7 @@ collections:
       value_field: username
       widget: relation
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -11063,7 +11063,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -11215,7 +11215,7 @@ collections:
       value_field: username
       widget: relation
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -11277,7 +11277,7 @@ collections:
       value_field: username
       widget: relation
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -11342,7 +11342,7 @@ collections:
       required: false
       widget: object
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -11412,7 +11412,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -11482,7 +11482,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -11552,7 +11552,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -11622,7 +11622,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -11689,7 +11689,7 @@ collections:
       value_field: username
       widget: relation
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -11759,7 +11759,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -11911,7 +11911,7 @@ collections:
       value_field: username
       widget: relation
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -11973,7 +11973,7 @@ collections:
       value_field: username
       widget: relation
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -12038,7 +12038,7 @@ collections:
       required: false
       widget: object
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -12108,7 +12108,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -12178,7 +12178,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -12248,7 +12248,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -12318,7 +12318,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -12385,7 +12385,7 @@ collections:
       value_field: username
       widget: relation
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -12455,7 +12455,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -12607,7 +12607,7 @@ collections:
       value_field: username
       widget: relation
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -12669,7 +12669,7 @@ collections:
       value_field: username
       widget: relation
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -12734,7 +12734,7 @@ collections:
       required: false
       widget: object
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -12804,7 +12804,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -12874,7 +12874,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -12944,7 +12944,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -13014,7 +13014,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -13081,7 +13081,7 @@ collections:
       value_field: username
       widget: relation
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -13151,7 +13151,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -13303,7 +13303,7 @@ collections:
       value_field: username
       widget: relation
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -13365,7 +13365,7 @@ collections:
       value_field: username
       widget: relation
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -13430,7 +13430,7 @@ collections:
       required: false
       widget: object
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -13500,7 +13500,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -13570,7 +13570,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -13640,7 +13640,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -13710,7 +13710,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -13777,7 +13777,7 @@ collections:
       value_field: username
       widget: relation
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -13847,7 +13847,7 @@ collections:
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -13999,7 +13999,7 @@ collections:
       value_field: username
       widget: relation
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags
@@ -14061,7 +14061,7 @@ collections:
       value_field: username
       widget: relation
     - label: SEO Description
-      name: seo-description
+      name: description
       required: false
       widget: string
     - collection: seo-tags

--- a/exampleSite/static/admin/dev.yml
+++ b/exampleSite/static/admin/dev.yml
@@ -1,626 +1,11634 @@
 backend:
   name: git-gateway
-  branch: main
-local_backend: true
-media_folder: "static/img"
-public_folder: "/img"
 collections:
-  ##
-  # Specialty data config
-  ##
-  # role metadata for role slider
-  - label: "Role metadata"
-    name: "role-data"
-    folder: "data/roles/"
-    format: "json"
-    identifier_field: "name"
-    create: true
-    fields:
-      - {label: "Short Name", name: "title", widget: "string"}
-      - {label: "Role Name", name: "name", widget: "string"}
-      - {label: "Display Order", name: "order", widget: "number"}
-      - {label: "Color", name: "color", widget: "color"}
-      - {label: "Icon", name: "icon", widget: "string"}
-      - {label: "Link", name: "role_link", widget: "string"}
-      - {label: "Description", name: "role_text_md", widget: "markdown"}
-      - label: "Job Information"
-        name: "jobs"
-        widget: "list"
-        fields:
-          - {label: "Name", name: "name", widget: "string"}
-          - {label: "Link", name: "job_link", widget: "string"}
-          - {label: "Icon", name: "icon", widget: "string"}
-  # job landing page
-  - label: "Job landing pages"
-    name: "job-landing"
-    files:
-      - label: "Paladin"
-        name: "paladin"
-        file: "content/jobs/tanks/paladin/_index.md"
-        fields:
-        - {label: "Title", name: "title", widget: "string"}
-        - {label: "Job Name", name: "job_name", widget: "string"}
-        - {label: "Body", name: "body", widget: "markdown", required: false}
-      - label: "Warrior"
-        name: "warrior"
-        file: "content/jobs/tanks/warrior/_index.md"
-        fields:
-        - {label: "Title", name: "title", widget: "string"}
-        - {label: "Job Name", name: "job_name", widget: "string"}
-        - {label: "Body", name: "body", widget: "markdown", required: false}
-      - label: "Dark Knight"
-        name: "dark-knight"
-        file: "content/jobs/tanks/dark-knight/_index.md"
-        fields:
-        - {label: "Title", name: "title", widget: "string"}
-        - {label: "Job Name", name: "job_name", widget: "string"}
-        - {label: "Body", name: "body", widget: "markdown", required: false}
-      - label: "Gunbreaker"
-        name: "gunbreaker"
-        file: "content/jobs/tanks/gunbreaker/_index.md"
-        fields:
-        - {label: "Title", name: "title", widget: "string"}
-        - {label: "Job Name", name: "job_name", widget: "string"}
-        - {label: "Body", name: "body", widget: "markdown", required: false}
-      - label: "White Mage"
-        name: "white-mage"
-        file: "content/jobs/healers/white-mage/_index.md"
-        fields:
-        - {label: "Title", name: "title", widget: "string"}
-        - {label: "Job Name", name: "job_name", widget: "string"}
-        - {label: "Body", name: "body", widget: "markdown", required: false}
-      - label: "Scholar"
-        name: "scholar"
-        file: "content/jobs/healers/scholar/_index.md"
-        fields:
-        - {label: "Title", name: "title", widget: "string"}
-        - {label: "Job Name", name: "job_name", widget: "string"}
-        - {label: "Body", name: "body", widget: "markdown", required: false}
-      - label: "Astrologian"
-        name: "astrologian"
-        file: "content/jobs/healers/astrologian/_index.md"
-        fields:
-        - {label: "Title", name: "title", widget: "string"}
-        - {label: "Job Name", name: "job_name", widget: "string"}
-        - {label: "Body", name: "body", widget: "markdown", required: false}
-      - label: "Monk"
-        name: "monk"
-        file: "content/jobs/melee/monk/_index.md"
-        fields:
-        - {label: "Title", name: "title", widget: "string"}
-        - {label: "Job Name", name: "job_name", widget: "string"}
-        - {label: "Body", name: "body", widget: "markdown", required: false}
-      - label: "Dragoon"
-        name: "dragoon"
-        file: "content/jobs/melee/dragoon/_index.md"
-        fields:
-        - {label: "Title", name: "title", widget: "string"}
-        - {label: "Job Name", name: "job_name", widget: "string"}
-        - {label: "Body", name: "body", widget: "markdown", required: false}
-      - label: "Ninja"
-        name: "ninja"
-        file: "content/jobs/melee/ninja/_index.md"
-        fields:
-        - {label: "Title", name: "title", widget: "string"}
-        - {label: "Job Name", name: "job_name", widget: "string"}
-        - {label: "Body", name: "body", widget: "markdown", required: false}
-      - label: "Samurai"
-        name: "samurai"
-        file: "content/jobs/melee/samurai/_index.md"
-        fields:
-        - {label: "Title", name: "title", widget: "string"}
-        - {label: "Job Name", name: "job_name", widget: "string"}
-        - {label: "Body", name: "body", widget: "markdown", required: false}
-      - label: "Reaper"
-        name: "reaper"
-        file: "content/jobs/melee/reaper/_index.md"
-        fields:
-        - {label: "Title", name: "title", widget: "string"}
-        - {label: "Job Name", name: "job_name", widget: "string"}
-        - {label: "Body", name: "body", widget: "markdown", required: false}
-      - label: "Bard"
-        name: "bard"
-        file: "content/jobs/ranged/bard/_index.md"
-        fields:
-        - {label: "Title", name: "title", widget: "string"}
-        - {label: "Job Name", name: "job_name", widget: "string"}
-        - {label: "Body", name: "body", widget: "markdown", required: false}
-      - label: "Machinist"
-        name: "machinist"
-        file: "content/jobs/ranged/machinist/_index.md"
-        fields:
-        - {label: "Title", name: "title", widget: "string"}
-        - {label: "Job Name", name: "job_name", widget: "string"}
-        - {label: "Body", name: "body", widget: "markdown", required: false}
-      - label: "Dancer"
-        name: "dancer"
-        file: "content/jobs/ranged/dancer/_index.md"
-        fields:
-        - {label: "Title", name: "title", widget: "string"}
-        - {label: "Job Name", name: "job_name", widget: "string"}
-        - {label: "Body", name: "body", widget: "markdown", required: false}
-      - label: "Black Mage"
-        name: "black-mage"
-        file: "content/jobs/casters/black-mage/_index.md"
-        fields:
-        - {label: "Title", name: "title", widget: "string"}
-        - {label: "Job Name", name: "job_name", widget: "string"}
-        - {label: "Body", name: "body", widget: "markdown", required: false}
-      - label: "Summoner"
-        name: "summoner"
-        file: "content/jobs/casters/summoner/_index.md"
-        fields:
-        - {label: "Title", name: "title", widget: "string"}
-        - {label: "Job Name", name: "job_name", widget: "string"}
-        - {label: "Body", name: "body", widget: "markdown", required: false}
-      - label: "Red Mage"
-        name: "red-mage"
-        file: "content/jobs/casters/red-mage/_index.md"
-        fields:
-        - {label: "Title", name: "title", widget: "string"}
-        - {label: "Job Name", name: "job_name", widget: "string"}
-        - {label: "Body", name: "body", widget: "markdown", required: false}
-  # role landing page
-  - label: "Role landing pages"
-    name: "role-landing"
-    files:
-      - label: "Tanks"
-        name: "tanks"
-        media_folder: "/static/img/jobs/tanks"
-        public_folder: "/img/jobs/tanks"
-        file: "content/jobs/tanks/_index.md"
-        fields:
-        - {label: "Body", name: "body", widget: "markdown"}
-        - label: "Menu hierarchy"
-          name: "menu"
-          widget: "object"
-          fields:
-            - label: "Main"
-              name: "main"
-              widget: "object"
-              fields: 
-                - {label: "Name", name: "name", widget: "select", options: ["Tanks"], default: ["Tanks"]}
-                - {label: "Parent", name: "parent", widget: "select", options: ["jobs"], default: ["jobs"]}
-        - label: "Role"
-          name: "role"
-          widget: "select"
-          options: ["tanks"]
-          default: ["tanks"]
-        - {label: "Layout", name: "layout", widget: "select", options: ["role_home"], default: ["role_home"]}
-        - {label: "Background Header Image", name: "bg_header_image", widget: "image", choose_url: false}
-        - {label: "Role Hero Image", name: "role_hero_image", widget: "image", choose_url: false}
-      - label: "Healers"
-        name: "healers"
-        file: "content/jobs/healers/_index.md"
-        media_folder: "/static/img/jobs/healers"
-        public_folder: "/img/jobs/healers"
-        fields:
-        - {label: "Body", name: "body", widget: "markdown"}
-        - label: "Menu hierarchy"
-          name: "menu"
-          widget: "object"
-          fields:
-            - label: "Main"
-              name: "main"
-              widget: "object"
-              fields: 
-                - {label: "Name", name: "name", widget: "select", options: ["Healers"], default: ["Healers"]}
-                - {label: "Parent", name: "parent", widget: "select", options: ["jobs"], default: ["jobs"]}
-        - label: "Role"
-          name: "role"
-          widget: "select"
-          options: ["healers"]
-          default: ["healers"]
-        - {label: "Layout", name: "layout", widget: "select", options: ["role_home"], default: ["role_home"]}
-        - {label: "Background Header Image", name: "bg_header_image", widget: "image", choose_url: false}
-        - {label: "Role Hero Image", name: "role_hero_image", widget: "image", choose_url: false}
-      - label: "Melee"
-        name: "melee"
-        file: "content/jobs/melee/_index.md"
-        media_folder: "/static/img/jobs/melee"
-        public_folder: "/img/jobs/melee"
-        fields:
-        - {label: "Body", name: "body", widget: "markdown"}
-        - label: "Menu hierarchy"
-          name: "menu"
-          widget: "object"
-          fields:
-            - label: "Main"
-              name: "main"
-              widget: "object"
-              fields: 
-                - {label: "Name", name: "name", widget: "select", options: ["Melee"], default: ["Melee"]}
-                - {label: "Parent", name: "parent", widget: "select", options: ["jobs"], default: ["jobs"]}
-        - label: "Role"
-          name: "role"
-          widget: "select"
-          options: ["melee"]
-          default: ["melee"]
-        - {label: "Layout", name: "layout", widget: "select", options: ["role_home"], default: ["role_home"]}
-        - {label: "Background Header Image", name: "bg_header_image", widget: "image", choose_url: false}
-        - {label: "Role Hero Image", name: "role_hero_image", widget: "image", choose_url: false}
-      - label: "Ranged"
-        name: "ranged"
-        file: "content/jobs/ranged/_index.md"
-        media_folder: "/static/img/jobs/ranged"
-        public_folder: "/img/jobs/ranged"
-        fields:
-        - {label: "Body", name: "body", widget: "markdown"}
-        - label: "Menu hierarchy"
-          name: "menu"
-          widget: "object"
-          fields:
-            - label: "Main"
-              name: "main"
-              widget: "object"
-              fields: 
-                - {label: "Name", name: "name", widget: "select", options: ["Ranged"], default: ["Ranged"]}
-                - {label: "Parent", name: "parent", widget: "select", options: ["jobs"], default: ["jobs"]}
-        - label: "Role"
-          name: "role"
-          widget: "select"
-          options: ["ranged"]
-          default: ["ranged"]
-        - {label: "Layout", name: "layout", widget: "select", options: ["role_home"], default: ["role_home"]}
-        - {label: "Background Header Image", name: "bg_header_image", widget: "image", choose_url: false}
-        - {label: "Role Hero Image", name: "role_hero_image", widget: "image", choose_url: false}
-      - label: "Casters"
-        name: "casters"
-        file: "content/jobs/casters/_index.md"
-        media_folder: "/static/img/jobs/casters"
-        public_folder: "/img/jobs/casters"
-        fields:
-        - {label: "Body", name: "body", widget: "markdown"}
-        - label: "Menu hierarchy"
-          name: "menu"
-          widget: "object"
-          fields:
-            - label: "Main"
-              name: "main"
-              widget: "object"
-              fields: 
-                - {label: "Name", name: "name", widget: "select", options: ["Casters"], default: ["Casters"]}
-                - {label: "Parent", name: "parent", widget: "select", options: ["jobs"], default: ["jobs"]}
-        - label: "Role"
-          name: "role"
-          widget: "select"
-          options: ["casters"]
-          default: ["casters"]
-        - {label: "Layout", name: "layout", widget: "select", options: ["role_home"], default: ["role_home"]}
-        - {label: "Background Header Image", name: "bg_header_image", widget: "image", choose_url: false}
-        - {label: "Role Hero Image", name: "role_hero_image", widget: "image", choose_url: false}
-  # user "profiles"
-  - label: "Author profile"
-    name: "author-profile"
-    folder: "data/author/"
-    format: "json"
-    identifier_field: "username"
-    media_folder: '/static/img/profile'
-    public_folder: '/img/profile'
-    create: true
-    fields:
-      - {label: "Username", name: "username", widget: "string"}
-      - {label: "Profile Image", name: "image", widget: "image", choose_url: false}
-      - {label: "Display Name", name: "name", widget: "string"}
-      - label: "Social information"
-        name: "socials"
-        widget: "object"
-        fields:
-          - {label: "Discord Name", name: "discord_id", widget: "string"}
-  # Encounters Metadata
-  - label: "Encounters"
-    name: "encounter-data"
-    folder: "content/encounters"
-    identifier_field: "fight_title"
-    create: true
-    fields:
-      - {label: "Fight Name",
-        name: "title", 
-        hint: This is the fight name (Ex. "E12 (Eternity)" or "O12 (Alphascape 4.0)"),
-        widget: "string"}
-      - {label: "Short Name of Fight", 
-        name: "fight_title", 
-        hint: This is the short name of the fight (Ex. "o12s" or "e12s-p2"),
-        widget: "string"}
-      - {label: "Encounter Category", 
-        name: "encounter_category", 
-        widget: "select", 
-        options: ["savage", "ultimate", "extreme"]}
-      - {label: "Fight Card Image", name: "card_image", widget: "image", choose_url: false}
-      - {label: "Fight Banner (for individual guides)", name: "banner_image", widget: "image", choose_url: false}
-      - {label: "Encounter Tier Image", name: "tier_image", widget: "image", choose_url: false, required: false}
-      - {label: "Encounter Tier Name", 
-        name: "tier_name", 
-        hint: Please capitalize the name (Ex. "Eden's Promise" or "Alphascape"),
-        widget: "string"}
-      - {label: "Encounter Series Name (Capitalized)", 
-        name: "series_name", 
-        hint: Please capitalize the series name (Ex. "Eden Series" or "Alexander Series"),
-        widget: "string"}
-      - {label: "Weight", 
-        name: "weight", 
-        hint: (1 - first, 2 - second, etc.)
-        widget: "number"}
-      - {label: "Tier Weight",
-        name: "tier_weight",
-        hint: (1 - EW, 2 - ShB, 3 - SB, 4 - HW, 5 - ARR)
-        widget: "number"}
-      - {label: "Coming Soon?", 
-        name: "coming_soon", 
-        hint: This adds the coming soon overlay. Only enable Coming Soon or Spoilers. Not both.,
-        widget: "boolean", 
-        required: false}
-      - {label: "Spoilers?", 
-        name: "spoilers", 
-        hint: This adds the spoiler overlay. Only enable Coming Soon or Spoilers. Not both.,
-        widget: "boolean", 
-        required: false}
-      - {label: "Expansion", name: "expansion", widget: "select", options: ["ew", "shb", "sb", "hw", "arr"]}
-      - {label: "Body", name: "body", widget: "markdown"}
-      - label: "Author(s)"
-        name: "authors"
-        widget: "relation"
-        multiple: true
-        collection: "author-profile"
-        search_fields: ["username", "name"]
-        value_field: "username"
-        display_fields: ["username", "name"]
-      - {label: "Last Updated", name: "lastmod", widget: "datetime", date_format: "YYYY-MM-DD", time_format: false}
-      - {label: "Patch", name: "patch", widget: "string"}
-      - label: "Changelog entry"
-        name: "changelog"
-        widget: "list"
-        summary: "{{fields.date}}: {{fields.message}}"
-        fields:
-          - {label: "Date", name: "date", widget: "datetime", date_format: "YYYY-MM-DD", time_format: false}
-          - {label: "Message", name: "message", widget: "string"}
-  ##
-  # Scholar guide
-  ##
-  - label: "Scholar guide"
-    name: "sch-guide"
-    media_folder: "/static/img/jobs"
-    public_folder: "/img/jobs"
-    files:
-      - label: "Landing page"
-        name: "landing"
-        file: "content/jobs/healers/scholar/_index.md"
-        fields:
-          - {label: "Body", name: "body", widget: "markdown"}
-      - label: "Leveling Guide"
-        name: "leveling-guide"
-        file: "content/jobs/healers/scholar/leveling-guide.md"
-        fields:
-          - {label: "Body", name: "body", widget: "markdown"}
-          - { label: "Card Header Image", name: "card_header_image", widget: "image", choose_url: false, required: false }
-          - label: "Author(s)"
-            name: "authors"
-            widget: "relation"
-            multiple: true
-            collection: "author-profile"
-            search_fields: ["username", "name"]
-            value_field: "username"
-            display_fields: ["username", "name"]
-          - {label: "Patch", name: "patch", widget: "string"}
-          - {label: "Last Updated", name: "lastmod", widget: "datetime", date_format: "YYYY-MM-DD", time_format: false}
-          - label: "Changelog entry"
-            name: "changelog"
-            widget: "list"
-            summary: "{{fields.date}}: {{fields.message}}"
-            fields:
-              - {label: "Date", name: "date", widget: "datetime", date_format: "YYYY-MM-DD", time_format: false}
-              - {label: "Message", name: "message", widget: "string"}
-      - label: "Basic guide"
-        name: "basic-guide"
-        file: "content/jobs/healers/scholar/basic-guide.md"
-        fields:
-          - {label: "Body", name: "body", widget: "markdown"}
-          - { label: "Card Header Image", name: "card_header_image", widget: "image", choose_url: false, required: false }
-          - label: "Author(s)"
-            name: "authors"
-            widget: "relation"
-            multiple: true
-            collection: "author-profile"
-            search_fields: ["username", "name"]
-            value_field: "username"
-            display_fields: ["username", "name"]
-          - {label: "Patch", name: "patch", widget: "string"}
-          - {label: "Last Updated", name: "lastmod", widget: "datetime", date_format: "YYYY-MM-DD", time_format: false}
-          - label: "Changelog entry"
-            name: "changelog"
-            widget: "list"
-            summary: "{{fields.date}}: {{fields.message}}"
-            fields:
-              - {label: "Date", name: "date", widget: "datetime", date_format: "YYYY-MM-DD", time_format: false}
-              - {label: "Message", name: "message", widget: "string"}
-      - label: "Skills overview"
-        name: "skills-overview"
-        file: "content/jobs/healers/scholar/skills-overview.md"
-        fields:
-          - {label: "Body", name: "body", widget: "markdown"}
-          - { label: "Card Header Image", name: "card_header_image", widget: "image", choose_url: false, required: false }
-          - label: "Author(s)"
-            name: "authors"
-            widget: "relation"
-            multiple: true
-            collection: "author-profile"
-            search_fields: ["username", "name"]
-            value_field: "username"
-            display_fields: ["username", "name"]
-          - {label: "Patch", name: "patch", widget: "string"}
-          - {label: "Last Updated", name: "lastmod", widget: "datetime", date_format: "YYYY-MM-DD", time_format: false}
-          - label: "Changelog entry"
-            name: "changelog"
-            widget: "list"
-            summary: "{{fields.date}}: {{fields.message}}"
-            fields:
-              - {label: "Date", name: "date", widget: "datetime", date_format: "YYYY-MM-DD", time_format: false}
-              - {label: "Message", name: "message", widget: "string"}
-      - label: "Openers"
-        name: "openers"
-        file: "content/jobs/healers/scholar/openers.md"
-        fields:
-          - {label: "Body", name: "body", widget: "markdown"}
-          - { label: "Card Header Image", name: "card_header_image", widget: "image", choose_url: false, required: false }
-          - label: "Author(s)"
-            name: "authors"
-            widget: "relation"
-            multiple: true
-            collection: "author-profile"
-            search_fields: ["username", "name"]
-            value_field: "username"
-            display_fields: ["username", "name"]
-          - {label: "Patch", name: "patch", widget: "string"}
-          - {label: "Last Updated", name: "lastmod", widget: "datetime", date_format: "YYYY-MM-DD", time_format: false}
-          - label: "Changelog entry"
-            name: "changelog"
-            widget: "list"
-            summary: "{{fields.date}}: {{fields.message}}"
-            fields:
-              - {label: "Date", name: "date", widget: "datetime", date_format: "YYYY-MM-DD", time_format: false}
-              - {label: "Message", name: "message", widget: "string"}
-      - label: "Frequently Asked Questions"
-        name: "faq"
-        file: "content/jobs/healers/scholar/faq.md"
-        fields:
-          - {label: "Layout", name: "layout", widget: "hidden", default: "qna"}
-          - {label: "Patch", name: "patch", widget: "string"}
-          - {label: "Last Updated", name: "lastmod", widget: "datetime", date_format: "YYYY-MM-DD", time_format: false}
-          - { label: "Card Header Image", name: "card_header_image", widget: "image", choose_url: false, required: false }
-          - label: "Author(s)"
-            name: "authors"
-            widget: "relation"
-            multiple: true
-            collection: "author-profile"
-            search_fields: ["username", "name"]
-            value_field: "username"
-            display_fields: ["username", "name"]
-          - label: "Changelog entry"
-            name: "changelog"
-            widget: "list"
-            summary: "{{fields.date}}: {{fields.message}}"
-            fields:
-              - {label: "Date", name: "date", widget: "datetime", date_format: "YYYY-MM-DD", time_format: false}
-              - {label: "Message", name: "message", widget: "string"}
-          - label: "FAQ Entry"
-            name: "qna"
-            widget: "list"
-            summary: "{{fields.question}}: {{fields.answer}}"
-            fields:
-              - {label: "Question", name: "question", widget: "string"}
-              - {label: "Answer", name: "answer", widget: "markdown"}
-      - label: "Advanced guide"
-        name: "advanced-guide"
-        file: "content/jobs/healers/scholar/advanced-guide.md"
-        fields:
-          - {label: "Body", name: "body", widget: "markdown"}
-          - { label: "Card Header Image", name: "card_header_image", widget: "image", choose_url: false, required: false }
-          - label: "Author(s)"
-            name: "authors"
-            widget: "relation"
-            multiple: true
-            collection: "author-profile"
-            search_fields: ["username", "name"]
-            value_field: "username"
-            display_fields: ["username", "name"]
-          - {label: "Patch", name: "patch", widget: "string"}
-          - {label: "Last Updated", name: "lastmod", widget: "datetime", date_format: "YYYY-MM-DD", time_format: false}
-          - label: "Changelog entry"
-            name: "changelog"
-            widget: "list"
-            summary: "{{fields.date}}: {{fields.message}}"
-            fields:
-              - {label: "Date", name: "date", widget: "datetime", date_format: "YYYY-MM-DD", time_format: false}
-              - {label: "Message", name: "message", widget: "string"}
-      - label: "Best in Slot"
-        name: "bis"
-        file: "content/jobs/healers/scholar/best-in-slot.md"
-        fields:
-          - {label: "Layout", name: "layout", widget: "hidden", default: "bis"}
-          - {label: "Patch", name: "patch", widget: "string"}
-          - { label: "Card Header Image", name: "card_header_image", widget: "image", choose_url: false, required: false }
-          - label: "Author(s)"
-            name: "authors"
-            widget: "relation"
-            multiple: true
-            collection: "author-profile"
-            search_fields: ["username", "name"]
-            value_field: "username"
-            display_fields: ["username", "name"]
-          - {label: "Last Updated", name: "lastmod", widget: "datetime", date_format: "YYYY-MM-DD", time_format: false}
-          - label: "Changelog entry"
-            name: "changelog"
-            widget: "list"
-            summary: "{{fields.date}}: {{fields.message}}"
-            fields:
-              - {label: "Date", name: "date", widget: "datetime", date_format: "YYYY-MM-DD", time_format: false}
-              - {label: "Message", name: "message", widget: "string"}
-          - label: "Sets"
-            name: "bis"
-            widget: "list"
-            summary: "{{fields.name}}"
-            fields:
-              - {label: "Name", name: "name", widget: "string"}
-              - {label: "Type", name: "type", widget: "select", options: ["etro"], default: "etro"}
-              - {label: "Set ID (the part after /gearset/)", name: "link", widget: "string"}
-              - {label: "Description", name: "description", widget: "markdown", required: false, default: ""}
-      - label: "Stat Priority"
-        name: "stat-priority"
-        file: "content/jobs/healers/scholar/stat-priority.md"
-        fields:
-          - {label: "Patch", name: "patch", widget: "string"}
-          - { label: "Card Header Image", name: "card_header_image", widget: "image", choose_url: false, required: false }
-          - label: "Author(s)"
-            name: "authors"
-            widget: "relation"
-            multiple: true
-            collection: "author-profile"
-            search_fields: ["username", "name"]
-            value_field: "username"
-            display_fields: ["username", "name"]
-          - {label: "Last Updated", name: "lastmod", widget: "datetime", date_format: "YYYY-MM-DD", time_format: false}
-          - label: "Changelog entry"
-            name: "changelog"
-            widget: "list"
-            summary: "{{fields.date}}: {{fields.message}}"
-            fields:
-              - {label: "Date", name: "date", widget: "datetime", date_format: "YYYY-MM-DD", time_format: false}
-              - {label: "Message", name: "message", widget: "string"}
-          - {label: "Priority", name: "priority", widget: "string"}
-      - label: "Job Changes"
-        name: "job-changes"
-        file: "content/jobs/healers/scholar/job-changes.md"
-        fields:
-          - {label: "Layout", name: "layout", widget: "hidden", default: "changes"}
-          - { label: "Card Header Image", name: "card_header_image", widget: "image", choose_url: false, required: false }
-          - label: "Change"
-            name: "changes"
-            widget: "list"
-            summary: "{{fields.patch}}"
-            fields:
-              - {label: "Patch", name: "patch", widget: "string"}
-              - {label: "Description", name: "description", widget: "markdown"}
-      - label: "Fight tips"
-        name: "fight-tips"
-        file: "content/jobs/healers/scholar/fight-tips.md"
-        fields:
-          - {label: "Body", name: "body", widget: "markdown"}
-          - { label: "Card Header Image", name: "card_header_image", widget: "image", choose_url: false, required: false }
-          - label: "Author(s)"
-            name: "authors"
-            widget: "relation"
-            multiple: true
-            collection: "author-profile"
-            search_fields: ["username", "name"]
-            value_field: "username"
-            display_fields: ["username", "name"]
-          - {label: "Patch", name: "patch", widget: "string"}
-          - {label: "Last Updated", name: "lastmod", widget: "datetime", date_format: "YYYY-MM-DD", time_format: false}
-          - label: "Changelog entry"
-            name: "changelog"
-            widget: "list"
-            summary: "{{fields.date}}: {{fields.message}}"
-            fields:
-              - {label: "Date", name: "date", widget: "datetime", date_format: "YYYY-MM-DD", time_format: false}
-              - {label: "Message", name: "message", widget: "string"}
-      
+- create: true
+  fields:
+  - label: Short name
+    name: title
+    required: false
+    widget: string
+  - label: Role name
+    name: name
+    required: false
+    widget: string
+  - label: Display order
+    name: order
+    required: false
+    widget: number
+  - label: Color
+    name: color
+    required: false
+    widget: color
+  - label: Icon
+    name: icon
+    required: false
+    widget: string
+  - label: Link
+    name: role_link
+    required: false
+    widget: string
+  - label: Description
+    name: role_text_md
+    required: false
+    widget: markdown
+  - fields:
+    - label: Name
+      name: name
+      required: false
+      widget: string
+    - label: Link
+      name: job_link
+      required: false
+      widget: string
+    - label: Icon
+      name: icon
+      required: false
+      widget: string
+    label: Job Information
+    name: jobs
+    required: false
+    widget: list
+  folder: data/roles/
+  format: json
+  identifier_field: name
+  label: Role Metadata
+  name: role-data
+- create: true
+  fields:
+  - label: Username
+    name: username
+    required: false
+    widget: string
+  - choose_url: false
+    label: Profile Image
+    name: image
+    required: false
+    widget: image
+  - label: Display Name
+    name: name
+    required: false
+    widget: string
+  - fields:
+    - label: Discord Name
+      name: discord_id
+      required: false
+      widget: string
+    label: Social Information
+    name: socials
+    required: false
+    widget: object
+  folder: data/author/
+  format: json
+  identifier_field: username
+  label: Author Profile
+  media_folder: /static/img/profile
+  name: author-profile
+  public_folder: /img/profile
+- files:
+  - fields:
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - fields:
+      - fields:
+        - default: Tanks
+          label: Name
+          name: name
+          options:
+          - Tanks
+          required: false
+          widget: select
+        - default:
+          - tanks
+          label: Identifier
+          name: identifier
+          options:
+          - tanks
+          required: false
+          widget: select
+        - default: jobs
+          label: Parent
+          name: parent
+          options:
+          - jobs
+          required: false
+          widget: select
+        label: Main
+        name: main
+        required: false
+        widget: object
+      label: Menu hierarchy
+      name: menu
+      required: false
+      widget: object
+    - default: tanks
+      label: Role
+      name: role
+      options:
+      - tanks
+      required: false
+      widget: select
+    - default: role_home
+      label: Layout
+      name: layout
+      options:
+      - role_home
+      required: false
+      widget: select
+    - choose_url: false
+      label: Background Header Image
+      name: bg_header_image
+      required: false
+      widget: image
+    - choose_url: false
+      label: Role Hero Image
+      name: role_hero_image
+      required: false
+      widget: image
+    file: content/jobs/tanks/_index.md
+    label: Tanks
+    media_folder: /static/img/jobs/tanks
+    name: tanks
+    public_folder: /img/jobs/tanks
+  - fields:
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - fields:
+      - fields:
+        - default: Healers
+          label: Name
+          name: name
+          options:
+          - Healers
+          required: false
+          widget: select
+        - default:
+          - healers
+          label: Identifier
+          name: identifier
+          options:
+          - healers
+          required: false
+          widget: select
+        - default: jobs
+          label: Parent
+          name: parent
+          options:
+          - jobs
+          required: false
+          widget: select
+        label: Main
+        name: main
+        required: false
+        widget: object
+      label: Menu hierarchy
+      name: menu
+      required: false
+      widget: object
+    - default: healers
+      label: Role
+      name: role
+      options:
+      - healers
+      required: false
+      widget: select
+    - default: role_home
+      label: Layout
+      name: layout
+      options:
+      - role_home
+      required: false
+      widget: select
+    - choose_url: false
+      label: Background Header Image
+      name: bg_header_image
+      required: false
+      widget: image
+    - choose_url: false
+      label: Role Hero Image
+      name: role_hero_image
+      required: false
+      widget: image
+    file: content/jobs/healers/_index.md
+    label: Healers
+    media_folder: /static/img/jobs/healers
+    name: healers
+    public_folder: /img/jobs/healers
+  - fields:
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - fields:
+      - fields:
+        - default: Melee
+          label: Name
+          name: name
+          options:
+          - Melee
+          required: false
+          widget: select
+        - default:
+          - melee
+          label: Identifier
+          name: identifier
+          options:
+          - melee
+          required: false
+          widget: select
+        - default: jobs
+          label: Parent
+          name: parent
+          options:
+          - jobs
+          required: false
+          widget: select
+        label: Main
+        name: main
+        required: false
+        widget: object
+      label: Menu hierarchy
+      name: menu
+      required: false
+      widget: object
+    - default: melee
+      label: Role
+      name: role
+      options:
+      - melee
+      required: false
+      widget: select
+    - default: role_home
+      label: Layout
+      name: layout
+      options:
+      - role_home
+      required: false
+      widget: select
+    - choose_url: false
+      label: Background Header Image
+      name: bg_header_image
+      required: false
+      widget: image
+    - choose_url: false
+      label: Role Hero Image
+      name: role_hero_image
+      required: false
+      widget: image
+    file: content/jobs/melee/_index.md
+    label: Melee
+    media_folder: /static/img/jobs/melee
+    name: melee
+    public_folder: /img/jobs/melee
+  - fields:
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - fields:
+      - fields:
+        - default: Ranged
+          label: Name
+          name: name
+          options:
+          - Ranged
+          required: false
+          widget: select
+        - default:
+          - ranged
+          label: Identifier
+          name: identifier
+          options:
+          - ranged
+          required: false
+          widget: select
+        - default: jobs
+          label: Parent
+          name: parent
+          options:
+          - jobs
+          required: false
+          widget: select
+        label: Main
+        name: main
+        required: false
+        widget: object
+      label: Menu hierarchy
+      name: menu
+      required: false
+      widget: object
+    - default: ranged
+      label: Role
+      name: role
+      options:
+      - ranged
+      required: false
+      widget: select
+    - default: role_home
+      label: Layout
+      name: layout
+      options:
+      - role_home
+      required: false
+      widget: select
+    - choose_url: false
+      label: Background Header Image
+      name: bg_header_image
+      required: false
+      widget: image
+    - choose_url: false
+      label: Role Hero Image
+      name: role_hero_image
+      required: false
+      widget: image
+    file: content/jobs/ranged/_index.md
+    label: Ranged
+    media_folder: /static/img/jobs/ranged
+    name: ranged
+    public_folder: /img/jobs/ranged
+  - fields:
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - fields:
+      - fields:
+        - default: Casters
+          label: Name
+          name: name
+          options:
+          - Casters
+          required: false
+          widget: select
+        - default:
+          - casters
+          label: Identifier
+          name: identifier
+          options:
+          - casters
+          required: false
+          widget: select
+        - default: jobs
+          label: Parent
+          name: parent
+          options:
+          - jobs
+          required: false
+          widget: select
+        label: Main
+        name: main
+        required: false
+        widget: object
+      label: Menu hierarchy
+      name: menu
+      required: false
+      widget: object
+    - default: casters
+      label: Role
+      name: role
+      options:
+      - casters
+      required: false
+      widget: select
+    - default: role_home
+      label: Layout
+      name: layout
+      options:
+      - role_home
+      required: false
+      widget: select
+    - choose_url: false
+      label: Background Header Image
+      name: bg_header_image
+      required: false
+      widget: image
+    - choose_url: false
+      label: Role Hero Image
+      name: role_hero_image
+      required: false
+      widget: image
+    file: content/jobs/casters/_index.md
+    label: Casters
+    media_folder: /static/img/jobs/casters
+    name: casters
+    public_folder: /img/jobs/casters
+  label: Role Landing Pages
+  name: role-landing
+- create: true
+  fields:
+  - hint: This is the fight name (Ex. "E12 (Eternity)" or "O12 (Alphascape 4.0)")
+    label: Fight Name
+    name: title
+    required: false
+    widget: string
+  - hint: This is the short name of the fight (Ex. "o12s" or "e12s-p2")
+    label: Short Name of Fight
+    name: fight_title
+    required: false
+    widget: string
+  - label: Encounter Category
+    name: difficulty
+    options:
+    - savage
+    - ultimate
+    - extreme
+    required: false
+    widget: select
+  - choose_url: false
+    label: Fight Card Image
+    name: card_image
+    required: false
+    widget: image
+  - choose_url: false
+    label: Fight Banner (for individual guides)
+    name: banner_image
+    required: false
+    widget: image
+  - choose_url: false
+    label: Encounter Tier Image
+    name: tier_image
+    required: false
+    widget: image
+  - hint: Please capitalize the name (Ex. "Eden's Promise" or "Alphascape")
+    label: Encounter Tier Name
+    name: tier_name
+    required: false
+    widget: string
+  - hint: Please capitalize the series name (Ex. "Eden Series" or "Alexander Series")
+    label: Encounter Series Name (Capitalized)
+    name: series_name
+    required: false
+    widget: string
+  - hint: (1 - last fight of tier, 2 - third fight of tier, etc. Must be in reverse
+      order.)
+    label: Weight
+    name: weight
+    required: false
+    widget: number
+  - hint: (1 - EW, 2 - ShB, 3 - SB, 4 - HW, 5 - ARR)
+    label: Tier Weight
+    name: tier_weight
+    required: false
+    widget: number
+  - hint: This adds the coming soon overlay. Only enable Coming Soon or Spoilers.
+      Not both.
+    label: Coming Soon?
+    name: coming_soon
+    required: false
+    widget: boolean
+  - hint: This adds the spoiler overlay. Only enable Coming Soon or Spoilers. Not
+      both.
+    label: Spoilers?
+    name: spoilers
+    required: false
+    widget: boolean
+  - label: Expansion
+    name: expansion
+    options:
+    - ew
+    - shb
+    - sb
+    - hw
+    - arr
+    required: false
+    widget: select
+  - label: Body
+    name: body
+    required: false
+    widget: markdown
+  - collection: author-profile
+    display_fields:
+    - username
+    - name
+    label: Author(s)
+    multiple: true
+    name: authors
+    required: false
+    search_fields:
+    - username
+    - name
+    value_field: username
+    widget: relation
+  - date_format: YYYY-MM-DD
+    label: Last Updated
+    name: lastmod
+    required: false
+    time_format: false
+    widget: datetime
+  - label: Patch
+    name: patch
+    required: false
+    widget: string
+  - fields:
+    - date_format: YYYY-MM-DD
+      label: Date
+      name: date
+      required: false
+      time_format: false
+      widget: datetime
+    - label: Message
+      name: message
+      required: false
+      widget: string
+    label: Changelog Entry
+    name: changelog
+    required: false
+    summary: '{{fields.date}}: {{fields.message}}'
+    widget: list
+  folder: content/encounters/savage/pandaemonium
+  identifier_field: fight_title
+  label: pandaemonium
+  media_folder: /static/img/encounters/savage/pandaemonium
+  name: encounter-pandaemonium
+  public_folder: /img/encounters/savage/pandaemonium
+- create: true
+  fields:
+  - hint: This is the fight name (Ex. "E12 (Eternity)" or "O12 (Alphascape 4.0)")
+    label: Fight Name
+    name: title
+    required: false
+    widget: string
+  - hint: This is the short name of the fight (Ex. "o12s" or "e12s-p2")
+    label: Short Name of Fight
+    name: fight_title
+    required: false
+    widget: string
+  - label: Encounter Category
+    name: difficulty
+    options:
+    - savage
+    - ultimate
+    - extreme
+    required: false
+    widget: select
+  - choose_url: false
+    label: Fight Card Image
+    name: card_image
+    required: false
+    widget: image
+  - choose_url: false
+    label: Fight Banner (for individual guides)
+    name: banner_image
+    required: false
+    widget: image
+  - choose_url: false
+    label: Encounter Tier Image
+    name: tier_image
+    required: false
+    widget: image
+  - hint: Please capitalize the name (Ex. "Eden's Promise" or "Alphascape")
+    label: Encounter Tier Name
+    name: tier_name
+    required: false
+    widget: string
+  - hint: Please capitalize the series name (Ex. "Eden Series" or "Alexander Series")
+    label: Encounter Series Name (Capitalized)
+    name: series_name
+    required: false
+    widget: string
+  - hint: (1 - last fight of tier, 2 - third fight of tier, etc. Must be in reverse
+      order.)
+    label: Weight
+    name: weight
+    required: false
+    widget: number
+  - hint: (1 - EW, 2 - ShB, 3 - SB, 4 - HW, 5 - ARR)
+    label: Tier Weight
+    name: tier_weight
+    required: false
+    widget: number
+  - hint: This adds the coming soon overlay. Only enable Coming Soon or Spoilers.
+      Not both.
+    label: Coming Soon?
+    name: coming_soon
+    required: false
+    widget: boolean
+  - hint: This adds the spoiler overlay. Only enable Coming Soon or Spoilers. Not
+      both.
+    label: Spoilers?
+    name: spoilers
+    required: false
+    widget: boolean
+  - label: Expansion
+    name: expansion
+    options:
+    - ew
+    - shb
+    - sb
+    - hw
+    - arr
+    required: false
+    widget: select
+  - label: Body
+    name: body
+    required: false
+    widget: markdown
+  - collection: author-profile
+    display_fields:
+    - username
+    - name
+    label: Author(s)
+    multiple: true
+    name: authors
+    required: false
+    search_fields:
+    - username
+    - name
+    value_field: username
+    widget: relation
+  - date_format: YYYY-MM-DD
+    label: Last Updated
+    name: lastmod
+    required: false
+    time_format: false
+    widget: datetime
+  - label: Patch
+    name: patch
+    required: false
+    widget: string
+  - fields:
+    - date_format: YYYY-MM-DD
+      label: Date
+      name: date
+      required: false
+      time_format: false
+      widget: datetime
+    - label: Message
+      name: message
+      required: false
+      widget: string
+    label: Changelog Entry
+    name: changelog
+    required: false
+    summary: '{{fields.date}}: {{fields.message}}'
+    widget: list
+  folder: content/encounters/ultimate/ultimates
+  identifier_field: fight_title
+  label: ultimates
+  media_folder: /static/img/encounters/ultimate/ultimates
+  name: encounter-ultimates
+  public_folder: /img/encounters/ultimate/ultimates
+- create: true
+  fields:
+  - hint: This is the fight name (Ex. "E12 (Eternity)" or "O12 (Alphascape 4.0)")
+    label: Fight Name
+    name: title
+    required: false
+    widget: string
+  - hint: This is the short name of the fight (Ex. "o12s" or "e12s-p2")
+    label: Short Name of Fight
+    name: fight_title
+    required: false
+    widget: string
+  - label: Encounter Category
+    name: difficulty
+    options:
+    - savage
+    - ultimate
+    - extreme
+    required: false
+    widget: select
+  - choose_url: false
+    label: Fight Card Image
+    name: card_image
+    required: false
+    widget: image
+  - choose_url: false
+    label: Fight Banner (for individual guides)
+    name: banner_image
+    required: false
+    widget: image
+  - choose_url: false
+    label: Encounter Tier Image
+    name: tier_image
+    required: false
+    widget: image
+  - hint: Please capitalize the name (Ex. "Eden's Promise" or "Alphascape")
+    label: Encounter Tier Name
+    name: tier_name
+    required: false
+    widget: string
+  - hint: Please capitalize the series name (Ex. "Eden Series" or "Alexander Series")
+    label: Encounter Series Name (Capitalized)
+    name: series_name
+    required: false
+    widget: string
+  - hint: (1 - last fight of tier, 2 - third fight of tier, etc. Must be in reverse
+      order.)
+    label: Weight
+    name: weight
+    required: false
+    widget: number
+  - hint: (1 - EW, 2 - ShB, 3 - SB, 4 - HW, 5 - ARR)
+    label: Tier Weight
+    name: tier_weight
+    required: false
+    widget: number
+  - hint: This adds the coming soon overlay. Only enable Coming Soon or Spoilers.
+      Not both.
+    label: Coming Soon?
+    name: coming_soon
+    required: false
+    widget: boolean
+  - hint: This adds the spoiler overlay. Only enable Coming Soon or Spoilers. Not
+      both.
+    label: Spoilers?
+    name: spoilers
+    required: false
+    widget: boolean
+  - label: Expansion
+    name: expansion
+    options:
+    - ew
+    - shb
+    - sb
+    - hw
+    - arr
+    required: false
+    widget: select
+  - label: Body
+    name: body
+    required: false
+    widget: markdown
+  - collection: author-profile
+    display_fields:
+    - username
+    - name
+    label: Author(s)
+    multiple: true
+    name: authors
+    required: false
+    search_fields:
+    - username
+    - name
+    value_field: username
+    widget: relation
+  - date_format: YYYY-MM-DD
+    label: Last Updated
+    name: lastmod
+    required: false
+    time_format: false
+    widget: datetime
+  - label: Patch
+    name: patch
+    required: false
+    widget: string
+  - fields:
+    - date_format: YYYY-MM-DD
+      label: Date
+      name: date
+      required: false
+      time_format: false
+      widget: datetime
+    - label: Message
+      name: message
+      required: false
+      widget: string
+    label: Changelog Entry
+    name: changelog
+    required: false
+    summary: '{{fields.date}}: {{fields.message}}'
+    widget: list
+  folder: content/encounters/extreme/extreme
+  identifier_field: fight_title
+  label: extreme
+  media_folder: /static/img/encounters/extreme/extreme
+  name: encounter-extreme
+  public_folder: /img/encounters/extreme/extreme
+- files:
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - default:
+      - paladin
+      label: Job Name
+      name: job_name
+      options:
+      - paladin
+      required: false
+      widget: select
+    - fields:
+      - fields:
+        - default:
+          - Paladin
+          label: Name
+          name: name
+          options:
+          - Paladin
+          required: false
+          widget: select
+        - default:
+          - tanks
+          label: Parent
+          name: parent
+          options:
+          - tanks
+          required: false
+          widget: select
+        label: Main
+        name: main
+        required: false
+        widget: object
+      label: Menu hierarchy
+      name: menu
+      required: false
+      widget: object
+    file: content/jobs/tanks/paladin/_index.md
+    label: Landing page
+    name: landing
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/tanks/paladin/leveling-guide.md
+    label: Leveling Guide
+    name: leveling-guide
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/tanks/paladin/basic-guide.md
+    label: Basic Guide
+    name: basic-guide
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/tanks/paladin/skills-overview.md
+    label: Skills Overview
+    name: skills-overview
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/tanks/paladin/openers.md
+    label: Openers and Rotation
+    name: openers
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - default:
+      - qna
+      label: Layout
+      name: layout
+      options:
+      - qna
+      required: false
+      widget: select
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - label: Question
+        name: question
+        required: false
+        widget: string
+      - label: Answer
+        name: answer
+        required: false
+        widget: markdown
+      label: FAQ Entry
+      name: qna
+      required: false
+      summary: '{{fields.question}}: {{fields.answer}}'
+      widget: list
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/tanks/paladin/faq.md
+    label: Frequently Asked Questions
+    name: faq
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/tanks/paladin/advanced-guide.md
+    label: Advanced Guide
+    name: advanced-guide
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - default:
+      - bis
+      label: layout
+      name: layout
+      options:
+      - bis
+      required: false
+      widget: select
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    - fields:
+      - label: Name
+        name: name
+        required: false
+        widget: string
+      - default: etro
+        label: Type
+        name: type
+        options:
+        - etro
+        - ariyala
+        - gsheets
+        - sleepyshiba
+        required: false
+        widget: select
+      - label: Link
+        name: link
+        required: false
+        widget: string
+      - label: Description
+        name: description
+        required: false
+        widget: markdown
+      label: Sets
+      name: bis
+      required: false
+      summary: '{{fields.name}}'
+      widget: list
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/tanks/paladin/best-in-slot.md
+    label: Best in Slot
+    name: bis
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    - label: Priority
+      name: priority
+      required: false
+      widget: string
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/tanks/paladin/stat-priority.md
+    label: Stat Priority
+    name: stat-priority
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - default: changes
+      label: Layout
+      name: layout
+      options:
+      - changes
+      required: false
+      widget: select
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - label: Patch
+        name: patch
+        required: false
+        widget: string
+      - label: Description
+        name: description
+        required: false
+        widget: markdown
+      label: Change
+      name: changes
+      required: false
+      summary: '{{fields.patch}}'
+      widget: list
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/tanks/paladin/job-changes.md
+    label: Job Changes
+    name: job-changes
+  label: Paladin guide
+  media_folder: /static/img/jobs/pld
+  name: pld-guide
+  public_folder: /img/jobs/pld
+- files:
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - default:
+      - warrior
+      label: Job Name
+      name: job_name
+      options:
+      - warrior
+      required: false
+      widget: select
+    - fields:
+      - fields:
+        - default:
+          - Warrior
+          label: Name
+          name: name
+          options:
+          - Warrior
+          required: false
+          widget: select
+        - default:
+          - tanks
+          label: Parent
+          name: parent
+          options:
+          - tanks
+          required: false
+          widget: select
+        label: Main
+        name: main
+        required: false
+        widget: object
+      label: Menu hierarchy
+      name: menu
+      required: false
+      widget: object
+    file: content/jobs/tanks/warrior/_index.md
+    label: Landing page
+    name: landing
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/tanks/warrior/leveling-guide.md
+    label: Leveling Guide
+    name: leveling-guide
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/tanks/warrior/basic-guide.md
+    label: Basic Guide
+    name: basic-guide
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/tanks/warrior/skills-overview.md
+    label: Skills Overview
+    name: skills-overview
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/tanks/warrior/openers.md
+    label: Openers and Rotation
+    name: openers
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - default:
+      - qna
+      label: Layout
+      name: layout
+      options:
+      - qna
+      required: false
+      widget: select
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - label: Question
+        name: question
+        required: false
+        widget: string
+      - label: Answer
+        name: answer
+        required: false
+        widget: markdown
+      label: FAQ Entry
+      name: qna
+      required: false
+      summary: '{{fields.question}}: {{fields.answer}}'
+      widget: list
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/tanks/warrior/faq.md
+    label: Frequently Asked Questions
+    name: faq
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/tanks/warrior/advanced-guide.md
+    label: Advanced Guide
+    name: advanced-guide
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - default:
+      - bis
+      label: layout
+      name: layout
+      options:
+      - bis
+      required: false
+      widget: select
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    - fields:
+      - label: Name
+        name: name
+        required: false
+        widget: string
+      - default: etro
+        label: Type
+        name: type
+        options:
+        - etro
+        - ariyala
+        - gsheets
+        - sleepyshiba
+        required: false
+        widget: select
+      - label: Link
+        name: link
+        required: false
+        widget: string
+      - label: Description
+        name: description
+        required: false
+        widget: markdown
+      label: Sets
+      name: bis
+      required: false
+      summary: '{{fields.name}}'
+      widget: list
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/tanks/warrior/best-in-slot.md
+    label: Best in Slot
+    name: bis
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    - label: Priority
+      name: priority
+      required: false
+      widget: string
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/tanks/warrior/stat-priority.md
+    label: Stat Priority
+    name: stat-priority
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - default: changes
+      label: Layout
+      name: layout
+      options:
+      - changes
+      required: false
+      widget: select
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - label: Patch
+        name: patch
+        required: false
+        widget: string
+      - label: Description
+        name: description
+        required: false
+        widget: markdown
+      label: Change
+      name: changes
+      required: false
+      summary: '{{fields.patch}}'
+      widget: list
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/tanks/warrior/job-changes.md
+    label: Job Changes
+    name: job-changes
+  label: Warrior guide
+  media_folder: /static/img/jobs/war
+  name: war-guide
+  public_folder: /img/jobs/war
+- files:
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - default:
+      - dark knight
+      label: Job Name
+      name: job_name
+      options:
+      - dark knight
+      required: false
+      widget: select
+    - fields:
+      - fields:
+        - default:
+          - Dark Knight
+          label: Name
+          name: name
+          options:
+          - Dark Knight
+          required: false
+          widget: select
+        - default:
+          - tanks
+          label: Parent
+          name: parent
+          options:
+          - tanks
+          required: false
+          widget: select
+        label: Main
+        name: main
+        required: false
+        widget: object
+      label: Menu hierarchy
+      name: menu
+      required: false
+      widget: object
+    file: content/jobs/tanks/dark-knight/_index.md
+    label: Landing page
+    name: landing
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/tanks/dark-knight/leveling-guide.md
+    label: Leveling Guide
+    name: leveling-guide
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/tanks/dark-knight/basic-guide.md
+    label: Basic Guide
+    name: basic-guide
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/tanks/dark-knight/skills-overview.md
+    label: Skills Overview
+    name: skills-overview
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/tanks/dark-knight/openers.md
+    label: Openers and Rotation
+    name: openers
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - default:
+      - qna
+      label: Layout
+      name: layout
+      options:
+      - qna
+      required: false
+      widget: select
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - label: Question
+        name: question
+        required: false
+        widget: string
+      - label: Answer
+        name: answer
+        required: false
+        widget: markdown
+      label: FAQ Entry
+      name: qna
+      required: false
+      summary: '{{fields.question}}: {{fields.answer}}'
+      widget: list
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/tanks/dark-knight/faq.md
+    label: Frequently Asked Questions
+    name: faq
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/tanks/dark-knight/advanced-guide.md
+    label: Advanced Guide
+    name: advanced-guide
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - default:
+      - bis
+      label: layout
+      name: layout
+      options:
+      - bis
+      required: false
+      widget: select
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    - fields:
+      - label: Name
+        name: name
+        required: false
+        widget: string
+      - default: etro
+        label: Type
+        name: type
+        options:
+        - etro
+        - ariyala
+        - gsheets
+        - sleepyshiba
+        required: false
+        widget: select
+      - label: Link
+        name: link
+        required: false
+        widget: string
+      - label: Description
+        name: description
+        required: false
+        widget: markdown
+      label: Sets
+      name: bis
+      required: false
+      summary: '{{fields.name}}'
+      widget: list
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/tanks/dark-knight/best-in-slot.md
+    label: Best in Slot
+    name: bis
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    - label: Priority
+      name: priority
+      required: false
+      widget: string
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/tanks/dark-knight/stat-priority.md
+    label: Stat Priority
+    name: stat-priority
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - default: changes
+      label: Layout
+      name: layout
+      options:
+      - changes
+      required: false
+      widget: select
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - label: Patch
+        name: patch
+        required: false
+        widget: string
+      - label: Description
+        name: description
+        required: false
+        widget: markdown
+      label: Change
+      name: changes
+      required: false
+      summary: '{{fields.patch}}'
+      widget: list
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/tanks/dark-knight/job-changes.md
+    label: Job Changes
+    name: job-changes
+  label: Dark Knight guide
+  media_folder: /static/img/jobs/drk
+  name: drk-guide
+  public_folder: /img/jobs/drk
+- files:
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - default:
+      - gunbreaker
+      label: Job Name
+      name: job_name
+      options:
+      - gunbreaker
+      required: false
+      widget: select
+    - fields:
+      - fields:
+        - default:
+          - Gunbreaker
+          label: Name
+          name: name
+          options:
+          - Gunbreaker
+          required: false
+          widget: select
+        - default:
+          - tanks
+          label: Parent
+          name: parent
+          options:
+          - tanks
+          required: false
+          widget: select
+        label: Main
+        name: main
+        required: false
+        widget: object
+      label: Menu hierarchy
+      name: menu
+      required: false
+      widget: object
+    file: content/jobs/tanks/gunbreaker/_index.md
+    label: Landing page
+    name: landing
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/tanks/gunbreaker/leveling-guide.md
+    label: Leveling Guide
+    name: leveling-guide
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/tanks/gunbreaker/basic-guide.md
+    label: Basic Guide
+    name: basic-guide
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/tanks/gunbreaker/skills-overview.md
+    label: Skills Overview
+    name: skills-overview
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/tanks/gunbreaker/openers.md
+    label: Openers and Rotation
+    name: openers
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - default:
+      - qna
+      label: Layout
+      name: layout
+      options:
+      - qna
+      required: false
+      widget: select
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - label: Question
+        name: question
+        required: false
+        widget: string
+      - label: Answer
+        name: answer
+        required: false
+        widget: markdown
+      label: FAQ Entry
+      name: qna
+      required: false
+      summary: '{{fields.question}}: {{fields.answer}}'
+      widget: list
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/tanks/gunbreaker/faq.md
+    label: Frequently Asked Questions
+    name: faq
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/tanks/gunbreaker/advanced-guide.md
+    label: Advanced Guide
+    name: advanced-guide
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - default:
+      - bis
+      label: layout
+      name: layout
+      options:
+      - bis
+      required: false
+      widget: select
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    - fields:
+      - label: Name
+        name: name
+        required: false
+        widget: string
+      - default: etro
+        label: Type
+        name: type
+        options:
+        - etro
+        - ariyala
+        - gsheets
+        - sleepyshiba
+        required: false
+        widget: select
+      - label: Link
+        name: link
+        required: false
+        widget: string
+      - label: Description
+        name: description
+        required: false
+        widget: markdown
+      label: Sets
+      name: bis
+      required: false
+      summary: '{{fields.name}}'
+      widget: list
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/tanks/gunbreaker/best-in-slot.md
+    label: Best in Slot
+    name: bis
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    - label: Priority
+      name: priority
+      required: false
+      widget: string
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/tanks/gunbreaker/stat-priority.md
+    label: Stat Priority
+    name: stat-priority
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - default: changes
+      label: Layout
+      name: layout
+      options:
+      - changes
+      required: false
+      widget: select
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - label: Patch
+        name: patch
+        required: false
+        widget: string
+      - label: Description
+        name: description
+        required: false
+        widget: markdown
+      label: Change
+      name: changes
+      required: false
+      summary: '{{fields.patch}}'
+      widget: list
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/tanks/gunbreaker/job-changes.md
+    label: Job Changes
+    name: job-changes
+  label: Gunbreaker guide
+  media_folder: /static/img/jobs/gbn
+  name: gbn-guide
+  public_folder: /img/jobs/gbn
+- files:
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - default:
+      - scholar
+      label: Job Name
+      name: job_name
+      options:
+      - scholar
+      required: false
+      widget: select
+    - fields:
+      - fields:
+        - default:
+          - Scholar
+          label: Name
+          name: name
+          options:
+          - Scholar
+          required: false
+          widget: select
+        - default:
+          - healers
+          label: Parent
+          name: parent
+          options:
+          - healers
+          required: false
+          widget: select
+        label: Main
+        name: main
+        required: false
+        widget: object
+      label: Menu hierarchy
+      name: menu
+      required: false
+      widget: object
+    file: content/jobs/tanks/scholar/_index.md
+    label: Landing page
+    name: landing
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/healers/scholar/leveling-guide.md
+    label: Leveling Guide
+    name: leveling-guide
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/healers/scholar/basic-guide.md
+    label: Basic Guide
+    name: basic-guide
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/healers/scholar/skills-overview.md
+    label: Skills Overview
+    name: skills-overview
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/healers/scholar/openers.md
+    label: Openers and Rotation
+    name: openers
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - default:
+      - qna
+      label: Layout
+      name: layout
+      options:
+      - qna
+      required: false
+      widget: select
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - label: Question
+        name: question
+        required: false
+        widget: string
+      - label: Answer
+        name: answer
+        required: false
+        widget: markdown
+      label: FAQ Entry
+      name: qna
+      required: false
+      summary: '{{fields.question}}: {{fields.answer}}'
+      widget: list
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/healers/scholar/faq.md
+    label: Frequently Asked Questions
+    name: faq
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/healers/scholar/advanced-guide.md
+    label: Advanced Guide
+    name: advanced-guide
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - default:
+      - bis
+      label: layout
+      name: layout
+      options:
+      - bis
+      required: false
+      widget: select
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    - fields:
+      - label: Name
+        name: name
+        required: false
+        widget: string
+      - default: etro
+        label: Type
+        name: type
+        options:
+        - etro
+        - ariyala
+        - gsheets
+        - sleepyshiba
+        required: false
+        widget: select
+      - label: Link
+        name: link
+        required: false
+        widget: string
+      - label: Description
+        name: description
+        required: false
+        widget: markdown
+      label: Sets
+      name: bis
+      required: false
+      summary: '{{fields.name}}'
+      widget: list
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/healers/scholar/best-in-slot.md
+    label: Best in Slot
+    name: bis
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    - label: Priority
+      name: priority
+      required: false
+      widget: string
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/healers/scholar/stat-priority.md
+    label: Stat Priority
+    name: stat-priority
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - default: changes
+      label: Layout
+      name: layout
+      options:
+      - changes
+      required: false
+      widget: select
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - label: Patch
+        name: patch
+        required: false
+        widget: string
+      - label: Description
+        name: description
+        required: false
+        widget: markdown
+      label: Change
+      name: changes
+      required: false
+      summary: '{{fields.patch}}'
+      widget: list
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/healers/scholar/job-changes.md
+    label: Job Changes
+    name: job-changes
+  label: Scholar guide
+  media_folder: /static/img/jobs/sch
+  name: sch-guide
+  public_folder: /img/jobs/sch
+- files:
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - default:
+      - white mage
+      label: Job Name
+      name: job_name
+      options:
+      - white mage
+      required: false
+      widget: select
+    - fields:
+      - fields:
+        - default:
+          - White Mage
+          label: Name
+          name: name
+          options:
+          - White Mage
+          required: false
+          widget: select
+        - default:
+          - healers
+          label: Parent
+          name: parent
+          options:
+          - healers
+          required: false
+          widget: select
+        label: Main
+        name: main
+        required: false
+        widget: object
+      label: Menu hierarchy
+      name: menu
+      required: false
+      widget: object
+    file: content/jobs/tanks/white-mage/_index.md
+    label: Landing page
+    name: landing
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/healers/white-mage/leveling-guide.md
+    label: Leveling Guide
+    name: leveling-guide
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/healers/white-mage/basic-guide.md
+    label: Basic Guide
+    name: basic-guide
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/healers/white-mage/skills-overview.md
+    label: Skills Overview
+    name: skills-overview
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/healers/white-mage/openers.md
+    label: Openers and Rotation
+    name: openers
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - default:
+      - qna
+      label: Layout
+      name: layout
+      options:
+      - qna
+      required: false
+      widget: select
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - label: Question
+        name: question
+        required: false
+        widget: string
+      - label: Answer
+        name: answer
+        required: false
+        widget: markdown
+      label: FAQ Entry
+      name: qna
+      required: false
+      summary: '{{fields.question}}: {{fields.answer}}'
+      widget: list
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/healers/white-mage/faq.md
+    label: Frequently Asked Questions
+    name: faq
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/healers/white-mage/advanced-guide.md
+    label: Advanced Guide
+    name: advanced-guide
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - default:
+      - bis
+      label: layout
+      name: layout
+      options:
+      - bis
+      required: false
+      widget: select
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    - fields:
+      - label: Name
+        name: name
+        required: false
+        widget: string
+      - default: etro
+        label: Type
+        name: type
+        options:
+        - etro
+        - ariyala
+        - gsheets
+        - sleepyshiba
+        required: false
+        widget: select
+      - label: Link
+        name: link
+        required: false
+        widget: string
+      - label: Description
+        name: description
+        required: false
+        widget: markdown
+      label: Sets
+      name: bis
+      required: false
+      summary: '{{fields.name}}'
+      widget: list
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/healers/white-mage/best-in-slot.md
+    label: Best in Slot
+    name: bis
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    - label: Priority
+      name: priority
+      required: false
+      widget: string
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/healers/white-mage/stat-priority.md
+    label: Stat Priority
+    name: stat-priority
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - default: changes
+      label: Layout
+      name: layout
+      options:
+      - changes
+      required: false
+      widget: select
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - label: Patch
+        name: patch
+        required: false
+        widget: string
+      - label: Description
+        name: description
+        required: false
+        widget: markdown
+      label: Change
+      name: changes
+      required: false
+      summary: '{{fields.patch}}'
+      widget: list
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/healers/white-mage/job-changes.md
+    label: Job Changes
+    name: job-changes
+  label: White Mage guide
+  media_folder: /static/img/jobs/whm
+  name: whm-guide
+  public_folder: /img/jobs/whm
+- files:
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - default:
+      - astrologian
+      label: Job Name
+      name: job_name
+      options:
+      - astrologian
+      required: false
+      widget: select
+    - fields:
+      - fields:
+        - default:
+          - Astrologian
+          label: Name
+          name: name
+          options:
+          - Astrologian
+          required: false
+          widget: select
+        - default:
+          - healers
+          label: Parent
+          name: parent
+          options:
+          - healers
+          required: false
+          widget: select
+        label: Main
+        name: main
+        required: false
+        widget: object
+      label: Menu hierarchy
+      name: menu
+      required: false
+      widget: object
+    file: content/jobs/tanks/astrologian/_index.md
+    label: Landing page
+    name: landing
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/healers/astrologian/leveling-guide.md
+    label: Leveling Guide
+    name: leveling-guide
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/healers/astrologian/basic-guide.md
+    label: Basic Guide
+    name: basic-guide
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/healers/astrologian/skills-overview.md
+    label: Skills Overview
+    name: skills-overview
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/healers/astrologian/openers.md
+    label: Openers and Rotation
+    name: openers
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - default:
+      - qna
+      label: Layout
+      name: layout
+      options:
+      - qna
+      required: false
+      widget: select
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - label: Question
+        name: question
+        required: false
+        widget: string
+      - label: Answer
+        name: answer
+        required: false
+        widget: markdown
+      label: FAQ Entry
+      name: qna
+      required: false
+      summary: '{{fields.question}}: {{fields.answer}}'
+      widget: list
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/healers/astrologian/faq.md
+    label: Frequently Asked Questions
+    name: faq
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/healers/astrologian/advanced-guide.md
+    label: Advanced Guide
+    name: advanced-guide
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - default:
+      - bis
+      label: layout
+      name: layout
+      options:
+      - bis
+      required: false
+      widget: select
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    - fields:
+      - label: Name
+        name: name
+        required: false
+        widget: string
+      - default: etro
+        label: Type
+        name: type
+        options:
+        - etro
+        - ariyala
+        - gsheets
+        - sleepyshiba
+        required: false
+        widget: select
+      - label: Link
+        name: link
+        required: false
+        widget: string
+      - label: Description
+        name: description
+        required: false
+        widget: markdown
+      label: Sets
+      name: bis
+      required: false
+      summary: '{{fields.name}}'
+      widget: list
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/healers/astrologian/best-in-slot.md
+    label: Best in Slot
+    name: bis
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    - label: Priority
+      name: priority
+      required: false
+      widget: string
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/healers/astrologian/stat-priority.md
+    label: Stat Priority
+    name: stat-priority
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - default: changes
+      label: Layout
+      name: layout
+      options:
+      - changes
+      required: false
+      widget: select
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - label: Patch
+        name: patch
+        required: false
+        widget: string
+      - label: Description
+        name: description
+        required: false
+        widget: markdown
+      label: Change
+      name: changes
+      required: false
+      summary: '{{fields.patch}}'
+      widget: list
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/healers/astrologian/job-changes.md
+    label: Job Changes
+    name: job-changes
+  label: Astrologian guide
+  media_folder: /static/img/jobs/ast
+  name: ast-guide
+  public_folder: /img/jobs/ast
+- files:
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - default:
+      - sage
+      label: Job Name
+      name: job_name
+      options:
+      - sage
+      required: false
+      widget: select
+    - fields:
+      - fields:
+        - default:
+          - Sage
+          label: Name
+          name: name
+          options:
+          - Sage
+          required: false
+          widget: select
+        - default:
+          - healers
+          label: Parent
+          name: parent
+          options:
+          - healers
+          required: false
+          widget: select
+        label: Main
+        name: main
+        required: false
+        widget: object
+      label: Menu hierarchy
+      name: menu
+      required: false
+      widget: object
+    file: content/jobs/tanks/sage/_index.md
+    label: Landing page
+    name: landing
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/healers/sage/leveling-guide.md
+    label: Leveling Guide
+    name: leveling-guide
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/healers/sage/basic-guide.md
+    label: Basic Guide
+    name: basic-guide
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/healers/sage/skills-overview.md
+    label: Skills Overview
+    name: skills-overview
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/healers/sage/openers.md
+    label: Openers and Rotation
+    name: openers
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - default:
+      - qna
+      label: Layout
+      name: layout
+      options:
+      - qna
+      required: false
+      widget: select
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - label: Question
+        name: question
+        required: false
+        widget: string
+      - label: Answer
+        name: answer
+        required: false
+        widget: markdown
+      label: FAQ Entry
+      name: qna
+      required: false
+      summary: '{{fields.question}}: {{fields.answer}}'
+      widget: list
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/healers/sage/faq.md
+    label: Frequently Asked Questions
+    name: faq
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/healers/sage/advanced-guide.md
+    label: Advanced Guide
+    name: advanced-guide
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - default:
+      - bis
+      label: layout
+      name: layout
+      options:
+      - bis
+      required: false
+      widget: select
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    - fields:
+      - label: Name
+        name: name
+        required: false
+        widget: string
+      - default: etro
+        label: Type
+        name: type
+        options:
+        - etro
+        - ariyala
+        - gsheets
+        - sleepyshiba
+        required: false
+        widget: select
+      - label: Link
+        name: link
+        required: false
+        widget: string
+      - label: Description
+        name: description
+        required: false
+        widget: markdown
+      label: Sets
+      name: bis
+      required: false
+      summary: '{{fields.name}}'
+      widget: list
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/healers/sage/best-in-slot.md
+    label: Best in Slot
+    name: bis
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    - label: Priority
+      name: priority
+      required: false
+      widget: string
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/healers/sage/stat-priority.md
+    label: Stat Priority
+    name: stat-priority
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - default: changes
+      label: Layout
+      name: layout
+      options:
+      - changes
+      required: false
+      widget: select
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - label: Patch
+        name: patch
+        required: false
+        widget: string
+      - label: Description
+        name: description
+        required: false
+        widget: markdown
+      label: Change
+      name: changes
+      required: false
+      summary: '{{fields.patch}}'
+      widget: list
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/healers/sage/job-changes.md
+    label: Job Changes
+    name: job-changes
+  label: Sage guide
+  media_folder: /static/img/jobs/sge
+  name: sge-guide
+  public_folder: /img/jobs/sge
+- files:
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - default:
+      - monk
+      label: Job Name
+      name: job_name
+      options:
+      - monk
+      required: false
+      widget: select
+    - fields:
+      - fields:
+        - default:
+          - Monk
+          label: Name
+          name: name
+          options:
+          - Monk
+          required: false
+          widget: select
+        - default:
+          - melee
+          label: Parent
+          name: parent
+          options:
+          - melee
+          required: false
+          widget: select
+        label: Main
+        name: main
+        required: false
+        widget: object
+      label: Menu hierarchy
+      name: menu
+      required: false
+      widget: object
+    file: content/jobs/tanks/monk/_index.md
+    label: Landing page
+    name: landing
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/melee/monk/leveling-guide.md
+    label: Leveling Guide
+    name: leveling-guide
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/melee/monk/basic-guide.md
+    label: Basic Guide
+    name: basic-guide
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/melee/monk/skills-overview.md
+    label: Skills Overview
+    name: skills-overview
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/melee/monk/openers.md
+    label: Openers and Rotation
+    name: openers
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - default:
+      - qna
+      label: Layout
+      name: layout
+      options:
+      - qna
+      required: false
+      widget: select
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - label: Question
+        name: question
+        required: false
+        widget: string
+      - label: Answer
+        name: answer
+        required: false
+        widget: markdown
+      label: FAQ Entry
+      name: qna
+      required: false
+      summary: '{{fields.question}}: {{fields.answer}}'
+      widget: list
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/melee/monk/faq.md
+    label: Frequently Asked Questions
+    name: faq
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/melee/monk/advanced-guide.md
+    label: Advanced Guide
+    name: advanced-guide
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - default:
+      - bis
+      label: layout
+      name: layout
+      options:
+      - bis
+      required: false
+      widget: select
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    - fields:
+      - label: Name
+        name: name
+        required: false
+        widget: string
+      - default: etro
+        label: Type
+        name: type
+        options:
+        - etro
+        - ariyala
+        - gsheets
+        - sleepyshiba
+        required: false
+        widget: select
+      - label: Link
+        name: link
+        required: false
+        widget: string
+      - label: Description
+        name: description
+        required: false
+        widget: markdown
+      label: Sets
+      name: bis
+      required: false
+      summary: '{{fields.name}}'
+      widget: list
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/melee/monk/best-in-slot.md
+    label: Best in Slot
+    name: bis
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    - label: Priority
+      name: priority
+      required: false
+      widget: string
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/melee/monk/stat-priority.md
+    label: Stat Priority
+    name: stat-priority
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - default: changes
+      label: Layout
+      name: layout
+      options:
+      - changes
+      required: false
+      widget: select
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - label: Patch
+        name: patch
+        required: false
+        widget: string
+      - label: Description
+        name: description
+        required: false
+        widget: markdown
+      label: Change
+      name: changes
+      required: false
+      summary: '{{fields.patch}}'
+      widget: list
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/melee/monk/job-changes.md
+    label: Job Changes
+    name: job-changes
+  label: Monk guide
+  media_folder: /static/img/jobs/mnk
+  name: mnk-guide
+  public_folder: /img/jobs/mnk
+- files:
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - default:
+      - dragoon
+      label: Job Name
+      name: job_name
+      options:
+      - dragoon
+      required: false
+      widget: select
+    - fields:
+      - fields:
+        - default:
+          - Dragoon
+          label: Name
+          name: name
+          options:
+          - Dragoon
+          required: false
+          widget: select
+        - default:
+          - melee
+          label: Parent
+          name: parent
+          options:
+          - melee
+          required: false
+          widget: select
+        label: Main
+        name: main
+        required: false
+        widget: object
+      label: Menu hierarchy
+      name: menu
+      required: false
+      widget: object
+    file: content/jobs/tanks/dragoon/_index.md
+    label: Landing page
+    name: landing
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/melee/dragoon/leveling-guide.md
+    label: Leveling Guide
+    name: leveling-guide
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/melee/dragoon/basic-guide.md
+    label: Basic Guide
+    name: basic-guide
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/melee/dragoon/skills-overview.md
+    label: Skills Overview
+    name: skills-overview
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/melee/dragoon/openers.md
+    label: Openers and Rotation
+    name: openers
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - default:
+      - qna
+      label: Layout
+      name: layout
+      options:
+      - qna
+      required: false
+      widget: select
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - label: Question
+        name: question
+        required: false
+        widget: string
+      - label: Answer
+        name: answer
+        required: false
+        widget: markdown
+      label: FAQ Entry
+      name: qna
+      required: false
+      summary: '{{fields.question}}: {{fields.answer}}'
+      widget: list
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/melee/dragoon/faq.md
+    label: Frequently Asked Questions
+    name: faq
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/melee/dragoon/advanced-guide.md
+    label: Advanced Guide
+    name: advanced-guide
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - default:
+      - bis
+      label: layout
+      name: layout
+      options:
+      - bis
+      required: false
+      widget: select
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    - fields:
+      - label: Name
+        name: name
+        required: false
+        widget: string
+      - default: etro
+        label: Type
+        name: type
+        options:
+        - etro
+        - ariyala
+        - gsheets
+        - sleepyshiba
+        required: false
+        widget: select
+      - label: Link
+        name: link
+        required: false
+        widget: string
+      - label: Description
+        name: description
+        required: false
+        widget: markdown
+      label: Sets
+      name: bis
+      required: false
+      summary: '{{fields.name}}'
+      widget: list
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/melee/dragoon/best-in-slot.md
+    label: Best in Slot
+    name: bis
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    - label: Priority
+      name: priority
+      required: false
+      widget: string
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/melee/dragoon/stat-priority.md
+    label: Stat Priority
+    name: stat-priority
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - default: changes
+      label: Layout
+      name: layout
+      options:
+      - changes
+      required: false
+      widget: select
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - label: Patch
+        name: patch
+        required: false
+        widget: string
+      - label: Description
+        name: description
+        required: false
+        widget: markdown
+      label: Change
+      name: changes
+      required: false
+      summary: '{{fields.patch}}'
+      widget: list
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/melee/dragoon/job-changes.md
+    label: Job Changes
+    name: job-changes
+  label: Dragoon guide
+  media_folder: /static/img/jobs/drg
+  name: drg-guide
+  public_folder: /img/jobs/drg
+- files:
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - default:
+      - ninja
+      label: Job Name
+      name: job_name
+      options:
+      - ninja
+      required: false
+      widget: select
+    - fields:
+      - fields:
+        - default:
+          - Ninja
+          label: Name
+          name: name
+          options:
+          - Ninja
+          required: false
+          widget: select
+        - default:
+          - melee
+          label: Parent
+          name: parent
+          options:
+          - melee
+          required: false
+          widget: select
+        label: Main
+        name: main
+        required: false
+        widget: object
+      label: Menu hierarchy
+      name: menu
+      required: false
+      widget: object
+    file: content/jobs/tanks/ninja/_index.md
+    label: Landing page
+    name: landing
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/melee/ninja/leveling-guide.md
+    label: Leveling Guide
+    name: leveling-guide
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/melee/ninja/basic-guide.md
+    label: Basic Guide
+    name: basic-guide
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/melee/ninja/skills-overview.md
+    label: Skills Overview
+    name: skills-overview
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/melee/ninja/openers.md
+    label: Openers and Rotation
+    name: openers
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - default:
+      - qna
+      label: Layout
+      name: layout
+      options:
+      - qna
+      required: false
+      widget: select
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - label: Question
+        name: question
+        required: false
+        widget: string
+      - label: Answer
+        name: answer
+        required: false
+        widget: markdown
+      label: FAQ Entry
+      name: qna
+      required: false
+      summary: '{{fields.question}}: {{fields.answer}}'
+      widget: list
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/melee/ninja/faq.md
+    label: Frequently Asked Questions
+    name: faq
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/melee/ninja/advanced-guide.md
+    label: Advanced Guide
+    name: advanced-guide
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - default:
+      - bis
+      label: layout
+      name: layout
+      options:
+      - bis
+      required: false
+      widget: select
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    - fields:
+      - label: Name
+        name: name
+        required: false
+        widget: string
+      - default: etro
+        label: Type
+        name: type
+        options:
+        - etro
+        - ariyala
+        - gsheets
+        - sleepyshiba
+        required: false
+        widget: select
+      - label: Link
+        name: link
+        required: false
+        widget: string
+      - label: Description
+        name: description
+        required: false
+        widget: markdown
+      label: Sets
+      name: bis
+      required: false
+      summary: '{{fields.name}}'
+      widget: list
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/melee/ninja/best-in-slot.md
+    label: Best in Slot
+    name: bis
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    - label: Priority
+      name: priority
+      required: false
+      widget: string
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/melee/ninja/stat-priority.md
+    label: Stat Priority
+    name: stat-priority
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - default: changes
+      label: Layout
+      name: layout
+      options:
+      - changes
+      required: false
+      widget: select
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - label: Patch
+        name: patch
+        required: false
+        widget: string
+      - label: Description
+        name: description
+        required: false
+        widget: markdown
+      label: Change
+      name: changes
+      required: false
+      summary: '{{fields.patch}}'
+      widget: list
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/melee/ninja/job-changes.md
+    label: Job Changes
+    name: job-changes
+  label: Ninja guide
+  media_folder: /static/img/jobs/nin
+  name: nin-guide
+  public_folder: /img/jobs/nin
+- files:
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - default:
+      - samurai
+      label: Job Name
+      name: job_name
+      options:
+      - samurai
+      required: false
+      widget: select
+    - fields:
+      - fields:
+        - default:
+          - Samurai
+          label: Name
+          name: name
+          options:
+          - Samurai
+          required: false
+          widget: select
+        - default:
+          - melee
+          label: Parent
+          name: parent
+          options:
+          - melee
+          required: false
+          widget: select
+        label: Main
+        name: main
+        required: false
+        widget: object
+      label: Menu hierarchy
+      name: menu
+      required: false
+      widget: object
+    file: content/jobs/tanks/samurai/_index.md
+    label: Landing page
+    name: landing
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/melee/samurai/leveling-guide.md
+    label: Leveling Guide
+    name: leveling-guide
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/melee/samurai/basic-guide.md
+    label: Basic Guide
+    name: basic-guide
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/melee/samurai/skills-overview.md
+    label: Skills Overview
+    name: skills-overview
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/melee/samurai/openers.md
+    label: Openers and Rotation
+    name: openers
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - default:
+      - qna
+      label: Layout
+      name: layout
+      options:
+      - qna
+      required: false
+      widget: select
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - label: Question
+        name: question
+        required: false
+        widget: string
+      - label: Answer
+        name: answer
+        required: false
+        widget: markdown
+      label: FAQ Entry
+      name: qna
+      required: false
+      summary: '{{fields.question}}: {{fields.answer}}'
+      widget: list
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/melee/samurai/faq.md
+    label: Frequently Asked Questions
+    name: faq
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/melee/samurai/advanced-guide.md
+    label: Advanced Guide
+    name: advanced-guide
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - default:
+      - bis
+      label: layout
+      name: layout
+      options:
+      - bis
+      required: false
+      widget: select
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    - fields:
+      - label: Name
+        name: name
+        required: false
+        widget: string
+      - default: etro
+        label: Type
+        name: type
+        options:
+        - etro
+        - ariyala
+        - gsheets
+        - sleepyshiba
+        required: false
+        widget: select
+      - label: Link
+        name: link
+        required: false
+        widget: string
+      - label: Description
+        name: description
+        required: false
+        widget: markdown
+      label: Sets
+      name: bis
+      required: false
+      summary: '{{fields.name}}'
+      widget: list
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/melee/samurai/best-in-slot.md
+    label: Best in Slot
+    name: bis
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    - label: Priority
+      name: priority
+      required: false
+      widget: string
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/melee/samurai/stat-priority.md
+    label: Stat Priority
+    name: stat-priority
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - default: changes
+      label: Layout
+      name: layout
+      options:
+      - changes
+      required: false
+      widget: select
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - label: Patch
+        name: patch
+        required: false
+        widget: string
+      - label: Description
+        name: description
+        required: false
+        widget: markdown
+      label: Change
+      name: changes
+      required: false
+      summary: '{{fields.patch}}'
+      widget: list
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/melee/samurai/job-changes.md
+    label: Job Changes
+    name: job-changes
+  label: Samurai guide
+  media_folder: /static/img/jobs/sam
+  name: sam-guide
+  public_folder: /img/jobs/sam
+- files:
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - default:
+      - reaper
+      label: Job Name
+      name: job_name
+      options:
+      - reaper
+      required: false
+      widget: select
+    - fields:
+      - fields:
+        - default:
+          - Reaper
+          label: Name
+          name: name
+          options:
+          - Reaper
+          required: false
+          widget: select
+        - default:
+          - melee
+          label: Parent
+          name: parent
+          options:
+          - melee
+          required: false
+          widget: select
+        label: Main
+        name: main
+        required: false
+        widget: object
+      label: Menu hierarchy
+      name: menu
+      required: false
+      widget: object
+    file: content/jobs/tanks/reaper/_index.md
+    label: Landing page
+    name: landing
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/melee/reaper/leveling-guide.md
+    label: Leveling Guide
+    name: leveling-guide
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/melee/reaper/basic-guide.md
+    label: Basic Guide
+    name: basic-guide
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/melee/reaper/skills-overview.md
+    label: Skills Overview
+    name: skills-overview
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/melee/reaper/openers.md
+    label: Openers and Rotation
+    name: openers
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - default:
+      - qna
+      label: Layout
+      name: layout
+      options:
+      - qna
+      required: false
+      widget: select
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - label: Question
+        name: question
+        required: false
+        widget: string
+      - label: Answer
+        name: answer
+        required: false
+        widget: markdown
+      label: FAQ Entry
+      name: qna
+      required: false
+      summary: '{{fields.question}}: {{fields.answer}}'
+      widget: list
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/melee/reaper/faq.md
+    label: Frequently Asked Questions
+    name: faq
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/melee/reaper/advanced-guide.md
+    label: Advanced Guide
+    name: advanced-guide
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - default:
+      - bis
+      label: layout
+      name: layout
+      options:
+      - bis
+      required: false
+      widget: select
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    - fields:
+      - label: Name
+        name: name
+        required: false
+        widget: string
+      - default: etro
+        label: Type
+        name: type
+        options:
+        - etro
+        - ariyala
+        - gsheets
+        - sleepyshiba
+        required: false
+        widget: select
+      - label: Link
+        name: link
+        required: false
+        widget: string
+      - label: Description
+        name: description
+        required: false
+        widget: markdown
+      label: Sets
+      name: bis
+      required: false
+      summary: '{{fields.name}}'
+      widget: list
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/melee/reaper/best-in-slot.md
+    label: Best in Slot
+    name: bis
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    - label: Priority
+      name: priority
+      required: false
+      widget: string
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/melee/reaper/stat-priority.md
+    label: Stat Priority
+    name: stat-priority
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - default: changes
+      label: Layout
+      name: layout
+      options:
+      - changes
+      required: false
+      widget: select
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - label: Patch
+        name: patch
+        required: false
+        widget: string
+      - label: Description
+        name: description
+        required: false
+        widget: markdown
+      label: Change
+      name: changes
+      required: false
+      summary: '{{fields.patch}}'
+      widget: list
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/melee/reaper/job-changes.md
+    label: Job Changes
+    name: job-changes
+  label: Reaper guide
+  media_folder: /static/img/jobs/rpr
+  name: rpr-guide
+  public_folder: /img/jobs/rpr
+- files:
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - default:
+      - bard
+      label: Job Name
+      name: job_name
+      options:
+      - bard
+      required: false
+      widget: select
+    - fields:
+      - fields:
+        - default:
+          - Bard
+          label: Name
+          name: name
+          options:
+          - Bard
+          required: false
+          widget: select
+        - default:
+          - ranged
+          label: Parent
+          name: parent
+          options:
+          - ranged
+          required: false
+          widget: select
+        label: Main
+        name: main
+        required: false
+        widget: object
+      label: Menu hierarchy
+      name: menu
+      required: false
+      widget: object
+    file: content/jobs/tanks/bard/_index.md
+    label: Landing page
+    name: landing
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/ranged/bard/leveling-guide.md
+    label: Leveling Guide
+    name: leveling-guide
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/ranged/bard/basic-guide.md
+    label: Basic Guide
+    name: basic-guide
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/ranged/bard/skills-overview.md
+    label: Skills Overview
+    name: skills-overview
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/ranged/bard/openers.md
+    label: Openers and Rotation
+    name: openers
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - default:
+      - qna
+      label: Layout
+      name: layout
+      options:
+      - qna
+      required: false
+      widget: select
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - label: Question
+        name: question
+        required: false
+        widget: string
+      - label: Answer
+        name: answer
+        required: false
+        widget: markdown
+      label: FAQ Entry
+      name: qna
+      required: false
+      summary: '{{fields.question}}: {{fields.answer}}'
+      widget: list
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/ranged/bard/faq.md
+    label: Frequently Asked Questions
+    name: faq
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/ranged/bard/advanced-guide.md
+    label: Advanced Guide
+    name: advanced-guide
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - default:
+      - bis
+      label: layout
+      name: layout
+      options:
+      - bis
+      required: false
+      widget: select
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    - fields:
+      - label: Name
+        name: name
+        required: false
+        widget: string
+      - default: etro
+        label: Type
+        name: type
+        options:
+        - etro
+        - ariyala
+        - gsheets
+        - sleepyshiba
+        required: false
+        widget: select
+      - label: Link
+        name: link
+        required: false
+        widget: string
+      - label: Description
+        name: description
+        required: false
+        widget: markdown
+      label: Sets
+      name: bis
+      required: false
+      summary: '{{fields.name}}'
+      widget: list
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/ranged/bard/best-in-slot.md
+    label: Best in Slot
+    name: bis
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    - label: Priority
+      name: priority
+      required: false
+      widget: string
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/ranged/bard/stat-priority.md
+    label: Stat Priority
+    name: stat-priority
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - default: changes
+      label: Layout
+      name: layout
+      options:
+      - changes
+      required: false
+      widget: select
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - label: Patch
+        name: patch
+        required: false
+        widget: string
+      - label: Description
+        name: description
+        required: false
+        widget: markdown
+      label: Change
+      name: changes
+      required: false
+      summary: '{{fields.patch}}'
+      widget: list
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/ranged/bard/job-changes.md
+    label: Job Changes
+    name: job-changes
+  label: Bard guide
+  media_folder: /static/img/jobs/brd
+  name: brd-guide
+  public_folder: /img/jobs/brd
+- files:
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - default:
+      - machinist
+      label: Job Name
+      name: job_name
+      options:
+      - machinist
+      required: false
+      widget: select
+    - fields:
+      - fields:
+        - default:
+          - Machinist
+          label: Name
+          name: name
+          options:
+          - Machinist
+          required: false
+          widget: select
+        - default:
+          - ranged
+          label: Parent
+          name: parent
+          options:
+          - ranged
+          required: false
+          widget: select
+        label: Main
+        name: main
+        required: false
+        widget: object
+      label: Menu hierarchy
+      name: menu
+      required: false
+      widget: object
+    file: content/jobs/tanks/machinist/_index.md
+    label: Landing page
+    name: landing
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/ranged/machinist/leveling-guide.md
+    label: Leveling Guide
+    name: leveling-guide
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/ranged/machinist/basic-guide.md
+    label: Basic Guide
+    name: basic-guide
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/ranged/machinist/skills-overview.md
+    label: Skills Overview
+    name: skills-overview
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/ranged/machinist/openers.md
+    label: Openers and Rotation
+    name: openers
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - default:
+      - qna
+      label: Layout
+      name: layout
+      options:
+      - qna
+      required: false
+      widget: select
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - label: Question
+        name: question
+        required: false
+        widget: string
+      - label: Answer
+        name: answer
+        required: false
+        widget: markdown
+      label: FAQ Entry
+      name: qna
+      required: false
+      summary: '{{fields.question}}: {{fields.answer}}'
+      widget: list
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/ranged/machinist/faq.md
+    label: Frequently Asked Questions
+    name: faq
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/ranged/machinist/advanced-guide.md
+    label: Advanced Guide
+    name: advanced-guide
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - default:
+      - bis
+      label: layout
+      name: layout
+      options:
+      - bis
+      required: false
+      widget: select
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    - fields:
+      - label: Name
+        name: name
+        required: false
+        widget: string
+      - default: etro
+        label: Type
+        name: type
+        options:
+        - etro
+        - ariyala
+        - gsheets
+        - sleepyshiba
+        required: false
+        widget: select
+      - label: Link
+        name: link
+        required: false
+        widget: string
+      - label: Description
+        name: description
+        required: false
+        widget: markdown
+      label: Sets
+      name: bis
+      required: false
+      summary: '{{fields.name}}'
+      widget: list
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/ranged/machinist/best-in-slot.md
+    label: Best in Slot
+    name: bis
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    - label: Priority
+      name: priority
+      required: false
+      widget: string
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/ranged/machinist/stat-priority.md
+    label: Stat Priority
+    name: stat-priority
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - default: changes
+      label: Layout
+      name: layout
+      options:
+      - changes
+      required: false
+      widget: select
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - label: Patch
+        name: patch
+        required: false
+        widget: string
+      - label: Description
+        name: description
+        required: false
+        widget: markdown
+      label: Change
+      name: changes
+      required: false
+      summary: '{{fields.patch}}'
+      widget: list
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/ranged/machinist/job-changes.md
+    label: Job Changes
+    name: job-changes
+  label: Machinist guide
+  media_folder: /static/img/jobs/mch
+  name: mch-guide
+  public_folder: /img/jobs/mch
+- files:
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - default:
+      - dancer
+      label: Job Name
+      name: job_name
+      options:
+      - dancer
+      required: false
+      widget: select
+    - fields:
+      - fields:
+        - default:
+          - Dancer
+          label: Name
+          name: name
+          options:
+          - Dancer
+          required: false
+          widget: select
+        - default:
+          - ranged
+          label: Parent
+          name: parent
+          options:
+          - ranged
+          required: false
+          widget: select
+        label: Main
+        name: main
+        required: false
+        widget: object
+      label: Menu hierarchy
+      name: menu
+      required: false
+      widget: object
+    file: content/jobs/tanks/dancer/_index.md
+    label: Landing page
+    name: landing
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/ranged/dancer/leveling-guide.md
+    label: Leveling Guide
+    name: leveling-guide
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/ranged/dancer/basic-guide.md
+    label: Basic Guide
+    name: basic-guide
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/ranged/dancer/skills-overview.md
+    label: Skills Overview
+    name: skills-overview
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/ranged/dancer/openers.md
+    label: Openers and Rotation
+    name: openers
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - default:
+      - qna
+      label: Layout
+      name: layout
+      options:
+      - qna
+      required: false
+      widget: select
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - label: Question
+        name: question
+        required: false
+        widget: string
+      - label: Answer
+        name: answer
+        required: false
+        widget: markdown
+      label: FAQ Entry
+      name: qna
+      required: false
+      summary: '{{fields.question}}: {{fields.answer}}'
+      widget: list
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/ranged/dancer/faq.md
+    label: Frequently Asked Questions
+    name: faq
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/ranged/dancer/advanced-guide.md
+    label: Advanced Guide
+    name: advanced-guide
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - default:
+      - bis
+      label: layout
+      name: layout
+      options:
+      - bis
+      required: false
+      widget: select
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    - fields:
+      - label: Name
+        name: name
+        required: false
+        widget: string
+      - default: etro
+        label: Type
+        name: type
+        options:
+        - etro
+        - ariyala
+        - gsheets
+        - sleepyshiba
+        required: false
+        widget: select
+      - label: Link
+        name: link
+        required: false
+        widget: string
+      - label: Description
+        name: description
+        required: false
+        widget: markdown
+      label: Sets
+      name: bis
+      required: false
+      summary: '{{fields.name}}'
+      widget: list
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/ranged/dancer/best-in-slot.md
+    label: Best in Slot
+    name: bis
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    - label: Priority
+      name: priority
+      required: false
+      widget: string
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/ranged/dancer/stat-priority.md
+    label: Stat Priority
+    name: stat-priority
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - default: changes
+      label: Layout
+      name: layout
+      options:
+      - changes
+      required: false
+      widget: select
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - label: Patch
+        name: patch
+        required: false
+        widget: string
+      - label: Description
+        name: description
+        required: false
+        widget: markdown
+      label: Change
+      name: changes
+      required: false
+      summary: '{{fields.patch}}'
+      widget: list
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/ranged/dancer/job-changes.md
+    label: Job Changes
+    name: job-changes
+  label: Dancer guide
+  media_folder: /static/img/jobs/dnc
+  name: dnc-guide
+  public_folder: /img/jobs/dnc
+- files:
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - default:
+      - black mage
+      label: Job Name
+      name: job_name
+      options:
+      - black mage
+      required: false
+      widget: select
+    - fields:
+      - fields:
+        - default:
+          - Black Mage
+          label: Name
+          name: name
+          options:
+          - Black Mage
+          required: false
+          widget: select
+        - default:
+          - casters
+          label: Parent
+          name: parent
+          options:
+          - casters
+          required: false
+          widget: select
+        label: Main
+        name: main
+        required: false
+        widget: object
+      label: Menu hierarchy
+      name: menu
+      required: false
+      widget: object
+    file: content/jobs/tanks/black-mage/_index.md
+    label: Landing page
+    name: landing
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/casters/black-mage/leveling-guide.md
+    label: Leveling Guide
+    name: leveling-guide
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/casters/black-mage/basic-guide.md
+    label: Basic Guide
+    name: basic-guide
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/casters/black-mage/skills-overview.md
+    label: Skills Overview
+    name: skills-overview
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/casters/black-mage/openers.md
+    label: Openers and Rotation
+    name: openers
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - default:
+      - qna
+      label: Layout
+      name: layout
+      options:
+      - qna
+      required: false
+      widget: select
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - label: Question
+        name: question
+        required: false
+        widget: string
+      - label: Answer
+        name: answer
+        required: false
+        widget: markdown
+      label: FAQ Entry
+      name: qna
+      required: false
+      summary: '{{fields.question}}: {{fields.answer}}'
+      widget: list
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/casters/black-mage/faq.md
+    label: Frequently Asked Questions
+    name: faq
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/casters/black-mage/advanced-guide.md
+    label: Advanced Guide
+    name: advanced-guide
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - default:
+      - bis
+      label: layout
+      name: layout
+      options:
+      - bis
+      required: false
+      widget: select
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    - fields:
+      - label: Name
+        name: name
+        required: false
+        widget: string
+      - default: etro
+        label: Type
+        name: type
+        options:
+        - etro
+        - ariyala
+        - gsheets
+        - sleepyshiba
+        required: false
+        widget: select
+      - label: Link
+        name: link
+        required: false
+        widget: string
+      - label: Description
+        name: description
+        required: false
+        widget: markdown
+      label: Sets
+      name: bis
+      required: false
+      summary: '{{fields.name}}'
+      widget: list
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/casters/black-mage/best-in-slot.md
+    label: Best in Slot
+    name: bis
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    - label: Priority
+      name: priority
+      required: false
+      widget: string
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/casters/black-mage/stat-priority.md
+    label: Stat Priority
+    name: stat-priority
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - default: changes
+      label: Layout
+      name: layout
+      options:
+      - changes
+      required: false
+      widget: select
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - label: Patch
+        name: patch
+        required: false
+        widget: string
+      - label: Description
+        name: description
+        required: false
+        widget: markdown
+      label: Change
+      name: changes
+      required: false
+      summary: '{{fields.patch}}'
+      widget: list
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/casters/black-mage/job-changes.md
+    label: Job Changes
+    name: job-changes
+  label: Black Mage guide
+  media_folder: /static/img/jobs/blm
+  name: blm-guide
+  public_folder: /img/jobs/blm
+- files:
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - default:
+      - red mage
+      label: Job Name
+      name: job_name
+      options:
+      - red mage
+      required: false
+      widget: select
+    - fields:
+      - fields:
+        - default:
+          - Red Mage
+          label: Name
+          name: name
+          options:
+          - Red Mage
+          required: false
+          widget: select
+        - default:
+          - casters
+          label: Parent
+          name: parent
+          options:
+          - casters
+          required: false
+          widget: select
+        label: Main
+        name: main
+        required: false
+        widget: object
+      label: Menu hierarchy
+      name: menu
+      required: false
+      widget: object
+    file: content/jobs/tanks/red-mage/_index.md
+    label: Landing page
+    name: landing
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/casters/red-mage/leveling-guide.md
+    label: Leveling Guide
+    name: leveling-guide
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/casters/red-mage/basic-guide.md
+    label: Basic Guide
+    name: basic-guide
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/casters/red-mage/skills-overview.md
+    label: Skills Overview
+    name: skills-overview
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/casters/red-mage/openers.md
+    label: Openers and Rotation
+    name: openers
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - default:
+      - qna
+      label: Layout
+      name: layout
+      options:
+      - qna
+      required: false
+      widget: select
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - label: Question
+        name: question
+        required: false
+        widget: string
+      - label: Answer
+        name: answer
+        required: false
+        widget: markdown
+      label: FAQ Entry
+      name: qna
+      required: false
+      summary: '{{fields.question}}: {{fields.answer}}'
+      widget: list
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/casters/red-mage/faq.md
+    label: Frequently Asked Questions
+    name: faq
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/casters/red-mage/advanced-guide.md
+    label: Advanced Guide
+    name: advanced-guide
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - default:
+      - bis
+      label: layout
+      name: layout
+      options:
+      - bis
+      required: false
+      widget: select
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    - fields:
+      - label: Name
+        name: name
+        required: false
+        widget: string
+      - default: etro
+        label: Type
+        name: type
+        options:
+        - etro
+        - ariyala
+        - gsheets
+        - sleepyshiba
+        required: false
+        widget: select
+      - label: Link
+        name: link
+        required: false
+        widget: string
+      - label: Description
+        name: description
+        required: false
+        widget: markdown
+      label: Sets
+      name: bis
+      required: false
+      summary: '{{fields.name}}'
+      widget: list
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/casters/red-mage/best-in-slot.md
+    label: Best in Slot
+    name: bis
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    - label: Priority
+      name: priority
+      required: false
+      widget: string
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/casters/red-mage/stat-priority.md
+    label: Stat Priority
+    name: stat-priority
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - default: changes
+      label: Layout
+      name: layout
+      options:
+      - changes
+      required: false
+      widget: select
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - label: Patch
+        name: patch
+        required: false
+        widget: string
+      - label: Description
+        name: description
+        required: false
+        widget: markdown
+      label: Change
+      name: changes
+      required: false
+      summary: '{{fields.patch}}'
+      widget: list
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/casters/red-mage/job-changes.md
+    label: Job Changes
+    name: job-changes
+  label: Red Mage guide
+  media_folder: /static/img/jobs/rdm
+  name: rdm-guide
+  public_folder: /img/jobs/rdm
+- files:
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - default:
+      - summoner
+      label: Job Name
+      name: job_name
+      options:
+      - summoner
+      required: false
+      widget: select
+    - fields:
+      - fields:
+        - default:
+          - Summoner
+          label: Name
+          name: name
+          options:
+          - Summoner
+          required: false
+          widget: select
+        - default:
+          - casters
+          label: Parent
+          name: parent
+          options:
+          - casters
+          required: false
+          widget: select
+        label: Main
+        name: main
+        required: false
+        widget: object
+      label: Menu hierarchy
+      name: menu
+      required: false
+      widget: object
+    file: content/jobs/tanks/summoner/_index.md
+    label: Landing page
+    name: landing
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/casters/summoner/leveling-guide.md
+    label: Leveling Guide
+    name: leveling-guide
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/casters/summoner/basic-guide.md
+    label: Basic Guide
+    name: basic-guide
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/casters/summoner/skills-overview.md
+    label: Skills Overview
+    name: skills-overview
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/casters/summoner/openers.md
+    label: Openers and Rotation
+    name: openers
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - default:
+      - qna
+      label: Layout
+      name: layout
+      options:
+      - qna
+      required: false
+      widget: select
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - label: Question
+        name: question
+        required: false
+        widget: string
+      - label: Answer
+        name: answer
+        required: false
+        widget: markdown
+      label: FAQ Entry
+      name: qna
+      required: false
+      summary: '{{fields.question}}: {{fields.answer}}'
+      widget: list
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/casters/summoner/faq.md
+    label: Frequently Asked Questions
+    name: faq
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - choose_url: false
+      label: Card Header Image
+      name: card_header_image
+      required: false
+      widget: image
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    file: content/jobs/casters/summoner/advanced-guide.md
+    label: Advanced Guide
+    name: advanced-guide
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - default:
+      - bis
+      label: layout
+      name: layout
+      options:
+      - bis
+      required: false
+      widget: select
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    - fields:
+      - label: Name
+        name: name
+        required: false
+        widget: string
+      - default: etro
+        label: Type
+        name: type
+        options:
+        - etro
+        - ariyala
+        - gsheets
+        - sleepyshiba
+        required: false
+        widget: select
+      - label: Link
+        name: link
+        required: false
+        widget: string
+      - label: Description
+        name: description
+        required: false
+        widget: markdown
+      label: Sets
+      name: bis
+      required: false
+      summary: '{{fields.name}}'
+      widget: list
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/casters/summoner/best-in-slot.md
+    label: Best in Slot
+    name: bis
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - label: Patch
+      name: patch
+      required: false
+      widget: string
+    - label: Body
+      name: body
+      required: false
+      widget: markdown
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - date_format: YYYY-MM-DD
+        label: Date
+        name: date
+        required: false
+        time_format: false
+        widget: datetime
+      - label: Message
+        name: message
+        required: false
+        widget: string
+      label: Changelog Entry
+      name: changelog
+      required: false
+      summary: '{{fields.date}}: {{fields.message}}'
+      widget: list
+    - label: Priority
+      name: priority
+      required: false
+      widget: string
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/casters/summoner/stat-priority.md
+    label: Stat Priority
+    name: stat-priority
+  - fields:
+    - label: Title
+      name: title
+      required: false
+      widget: string
+    - default: changes
+      label: Layout
+      name: layout
+      options:
+      - changes
+      required: false
+      widget: select
+    - date_format: YYYY-MM-DD
+      label: Last Updated
+      name: lastmod
+      required: false
+      time_format: false
+      widget: datetime
+    - fields:
+      - label: Patch
+        name: patch
+        required: false
+        widget: string
+      - label: Description
+        name: description
+        required: false
+        widget: markdown
+      label: Change
+      name: changes
+      required: false
+      summary: '{{fields.patch}}'
+      widget: list
+    - collection: author-profile
+      display_fields:
+      - username
+      - name
+      label: Author(s)
+      multiple: true
+      name: authors
+      required: false
+      search_fields:
+      - username
+      - name
+      value_field: username
+      widget: relation
+    file: content/jobs/casters/summoner/job-changes.md
+    label: Job Changes
+    name: job-changes
+  label: Summoner guide
+  media_folder: /static/img/jobs/smn
+  name: smn-guide
+  public_folder: /img/jobs/smn
+local_backend: true
+media_folder: static/img
+public_folder: /img
+

--- a/exampleSite/static/admin/dev.yml
+++ b/exampleSite/static/admin/dev.yml
@@ -84,6 +84,23 @@ collections:
   media_folder: /static/img/profile
   name: author-profile
   public_folder: /img/profile
+- create: true
+  fields:
+  - label: Tag
+    name: tag
+    required: false
+    widget: string
+  - label: Description
+    name: description
+    required: false
+    widget: string
+  folder: data/seo/tags
+  format: json
+  identifier_field: tag
+  label: SEO tags
+  media_folder: /static/img/profile
+  name: seo-tags
+  public_folder: /img/profile
 - files:
   - fields:
     - label: Body

--- a/exampleSite/static/admin/dev.yml
+++ b/exampleSite/static/admin/dev.yml
@@ -538,6 +538,20 @@ collections:
     required: false
     summary: '{{fields.date}}: {{fields.message}}'
     widget: list
+  - label: SEO Description
+    name: seo-description
+    required: false
+    widget: string
+  - collection: seo-tags
+    label: SEO Tags (only the first six can be used)
+    multiple: true
+    name: tags
+    required: false
+    search_fields:
+    - tag
+    - description
+    value_field: tag
+    widget: relation
   folder: content/encounters/savage/pandaemonium
   identifier_field: fight_title
   label: pandaemonium
@@ -665,6 +679,20 @@ collections:
     required: false
     summary: '{{fields.date}}: {{fields.message}}'
     widget: list
+  - label: SEO Description
+    name: seo-description
+    required: false
+    widget: string
+  - collection: seo-tags
+    label: SEO Tags (only the first six can be used)
+    multiple: true
+    name: tags
+    required: false
+    search_fields:
+    - tag
+    - description
+    value_field: tag
+    widget: relation
   folder: content/encounters/ultimate/ultimates
   identifier_field: fight_title
   label: ultimates
@@ -792,6 +820,20 @@ collections:
     required: false
     summary: '{{fields.date}}: {{fields.message}}'
     widget: list
+  - label: SEO Description
+    name: seo-description
+    required: false
+    widget: string
+  - collection: seo-tags
+    label: SEO Tags (only the first six can be used)
+    multiple: true
+    name: tags
+    required: false
+    search_fields:
+    - tag
+    - description
+    value_field: tag
+    widget: relation
   folder: content/encounters/extreme/extreme
   identifier_field: fight_title
   label: extreme
@@ -842,6 +884,20 @@ collections:
       name: menu
       required: false
       widget: object
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/tanks/paladin/_index.md
     label: Landing page
     name: landing
@@ -898,6 +954,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/tanks/paladin/leveling-guide.md
     label: Leveling Guide
     name: leveling-guide
@@ -954,6 +1024,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/tanks/paladin/basic-guide.md
     label: Basic Guide
     name: basic-guide
@@ -1010,6 +1094,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/tanks/paladin/skills-overview.md
     label: Skills Overview
     name: skills-overview
@@ -1066,6 +1164,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/tanks/paladin/openers.md
     label: Openers and Rotation
     name: openers
@@ -1118,6 +1230,20 @@ collections:
       - username
       - name
       value_field: username
+      widget: relation
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
       widget: relation
     file: content/jobs/tanks/paladin/faq.md
     label: Frequently Asked Questions
@@ -1175,6 +1301,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/tanks/paladin/advanced-guide.md
     label: Advanced Guide
     name: advanced-guide
@@ -1313,6 +1453,20 @@ collections:
       - name
       value_field: username
       widget: relation
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/tanks/paladin/stat-priority.md
     label: Stat Priority
     name: stat-priority
@@ -1360,6 +1514,20 @@ collections:
       - username
       - name
       value_field: username
+      widget: relation
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
       widget: relation
     file: content/jobs/tanks/paladin/job-changes.md
     label: Job Changes
@@ -1412,6 +1580,20 @@ collections:
       name: menu
       required: false
       widget: object
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/tanks/warrior/_index.md
     label: Landing page
     name: landing
@@ -1468,6 +1650,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/tanks/warrior/leveling-guide.md
     label: Leveling Guide
     name: leveling-guide
@@ -1524,6 +1720,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/tanks/warrior/basic-guide.md
     label: Basic Guide
     name: basic-guide
@@ -1580,6 +1790,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/tanks/warrior/skills-overview.md
     label: Skills Overview
     name: skills-overview
@@ -1636,6 +1860,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/tanks/warrior/openers.md
     label: Openers and Rotation
     name: openers
@@ -1688,6 +1926,20 @@ collections:
       - username
       - name
       value_field: username
+      widget: relation
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
       widget: relation
     file: content/jobs/tanks/warrior/faq.md
     label: Frequently Asked Questions
@@ -1745,6 +1997,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/tanks/warrior/advanced-guide.md
     label: Advanced Guide
     name: advanced-guide
@@ -1883,6 +2149,20 @@ collections:
       - name
       value_field: username
       widget: relation
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/tanks/warrior/stat-priority.md
     label: Stat Priority
     name: stat-priority
@@ -1930,6 +2210,20 @@ collections:
       - username
       - name
       value_field: username
+      widget: relation
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
       widget: relation
     file: content/jobs/tanks/warrior/job-changes.md
     label: Job Changes
@@ -1982,6 +2276,20 @@ collections:
       name: menu
       required: false
       widget: object
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/tanks/dark-knight/_index.md
     label: Landing page
     name: landing
@@ -2038,6 +2346,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/tanks/dark-knight/leveling-guide.md
     label: Leveling Guide
     name: leveling-guide
@@ -2094,6 +2416,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/tanks/dark-knight/basic-guide.md
     label: Basic Guide
     name: basic-guide
@@ -2150,6 +2486,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/tanks/dark-knight/skills-overview.md
     label: Skills Overview
     name: skills-overview
@@ -2206,6 +2556,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/tanks/dark-knight/openers.md
     label: Openers and Rotation
     name: openers
@@ -2258,6 +2622,20 @@ collections:
       - username
       - name
       value_field: username
+      widget: relation
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
       widget: relation
     file: content/jobs/tanks/dark-knight/faq.md
     label: Frequently Asked Questions
@@ -2315,6 +2693,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/tanks/dark-knight/advanced-guide.md
     label: Advanced Guide
     name: advanced-guide
@@ -2453,6 +2845,20 @@ collections:
       - name
       value_field: username
       widget: relation
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/tanks/dark-knight/stat-priority.md
     label: Stat Priority
     name: stat-priority
@@ -2500,6 +2906,20 @@ collections:
       - username
       - name
       value_field: username
+      widget: relation
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
       widget: relation
     file: content/jobs/tanks/dark-knight/job-changes.md
     label: Job Changes
@@ -2552,6 +2972,20 @@ collections:
       name: menu
       required: false
       widget: object
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/tanks/gunbreaker/_index.md
     label: Landing page
     name: landing
@@ -2608,6 +3042,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/tanks/gunbreaker/leveling-guide.md
     label: Leveling Guide
     name: leveling-guide
@@ -2664,6 +3112,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/tanks/gunbreaker/basic-guide.md
     label: Basic Guide
     name: basic-guide
@@ -2720,6 +3182,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/tanks/gunbreaker/skills-overview.md
     label: Skills Overview
     name: skills-overview
@@ -2776,6 +3252,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/tanks/gunbreaker/openers.md
     label: Openers and Rotation
     name: openers
@@ -2828,6 +3318,20 @@ collections:
       - username
       - name
       value_field: username
+      widget: relation
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
       widget: relation
     file: content/jobs/tanks/gunbreaker/faq.md
     label: Frequently Asked Questions
@@ -2885,6 +3389,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/tanks/gunbreaker/advanced-guide.md
     label: Advanced Guide
     name: advanced-guide
@@ -3023,6 +3541,20 @@ collections:
       - name
       value_field: username
       widget: relation
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/tanks/gunbreaker/stat-priority.md
     label: Stat Priority
     name: stat-priority
@@ -3070,6 +3602,20 @@ collections:
       - username
       - name
       value_field: username
+      widget: relation
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
       widget: relation
     file: content/jobs/tanks/gunbreaker/job-changes.md
     label: Job Changes
@@ -3122,6 +3668,20 @@ collections:
       name: menu
       required: false
       widget: object
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/healers/scholar/_index.md
     label: Landing page
     name: landing
@@ -3178,6 +3738,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/healers/scholar/leveling-guide.md
     label: Leveling Guide
     name: leveling-guide
@@ -3234,6 +3808,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/healers/scholar/basic-guide.md
     label: Basic Guide
     name: basic-guide
@@ -3290,6 +3878,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/healers/scholar/skills-overview.md
     label: Skills Overview
     name: skills-overview
@@ -3346,6 +3948,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/healers/scholar/openers.md
     label: Openers and Rotation
     name: openers
@@ -3398,6 +4014,20 @@ collections:
       - username
       - name
       value_field: username
+      widget: relation
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
       widget: relation
     file: content/jobs/healers/scholar/faq.md
     label: Frequently Asked Questions
@@ -3455,6 +4085,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/healers/scholar/advanced-guide.md
     label: Advanced Guide
     name: advanced-guide
@@ -3593,6 +4237,20 @@ collections:
       - name
       value_field: username
       widget: relation
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/healers/scholar/stat-priority.md
     label: Stat Priority
     name: stat-priority
@@ -3640,6 +4298,20 @@ collections:
       - username
       - name
       value_field: username
+      widget: relation
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
       widget: relation
     file: content/jobs/healers/scholar/job-changes.md
     label: Job Changes
@@ -3692,6 +4364,20 @@ collections:
       name: menu
       required: false
       widget: object
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/healers/white-mage/_index.md
     label: Landing page
     name: landing
@@ -3748,6 +4434,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/healers/white-mage/leveling-guide.md
     label: Leveling Guide
     name: leveling-guide
@@ -3804,6 +4504,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/healers/white-mage/basic-guide.md
     label: Basic Guide
     name: basic-guide
@@ -3860,6 +4574,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/healers/white-mage/skills-overview.md
     label: Skills Overview
     name: skills-overview
@@ -3916,6 +4644,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/healers/white-mage/openers.md
     label: Openers and Rotation
     name: openers
@@ -3968,6 +4710,20 @@ collections:
       - username
       - name
       value_field: username
+      widget: relation
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
       widget: relation
     file: content/jobs/healers/white-mage/faq.md
     label: Frequently Asked Questions
@@ -4025,6 +4781,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/healers/white-mage/advanced-guide.md
     label: Advanced Guide
     name: advanced-guide
@@ -4163,6 +4933,20 @@ collections:
       - name
       value_field: username
       widget: relation
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/healers/white-mage/stat-priority.md
     label: Stat Priority
     name: stat-priority
@@ -4210,6 +4994,20 @@ collections:
       - username
       - name
       value_field: username
+      widget: relation
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
       widget: relation
     file: content/jobs/healers/white-mage/job-changes.md
     label: Job Changes
@@ -4262,6 +5060,20 @@ collections:
       name: menu
       required: false
       widget: object
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/healers/astrologian/_index.md
     label: Landing page
     name: landing
@@ -4318,6 +5130,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/healers/astrologian/leveling-guide.md
     label: Leveling Guide
     name: leveling-guide
@@ -4374,6 +5200,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/healers/astrologian/basic-guide.md
     label: Basic Guide
     name: basic-guide
@@ -4430,6 +5270,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/healers/astrologian/skills-overview.md
     label: Skills Overview
     name: skills-overview
@@ -4486,6 +5340,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/healers/astrologian/openers.md
     label: Openers and Rotation
     name: openers
@@ -4538,6 +5406,20 @@ collections:
       - username
       - name
       value_field: username
+      widget: relation
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
       widget: relation
     file: content/jobs/healers/astrologian/faq.md
     label: Frequently Asked Questions
@@ -4595,6 +5477,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/healers/astrologian/advanced-guide.md
     label: Advanced Guide
     name: advanced-guide
@@ -4733,6 +5629,20 @@ collections:
       - name
       value_field: username
       widget: relation
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/healers/astrologian/stat-priority.md
     label: Stat Priority
     name: stat-priority
@@ -4780,6 +5690,20 @@ collections:
       - username
       - name
       value_field: username
+      widget: relation
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
       widget: relation
     file: content/jobs/healers/astrologian/job-changes.md
     label: Job Changes
@@ -4832,6 +5756,20 @@ collections:
       name: menu
       required: false
       widget: object
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/healers/sage/_index.md
     label: Landing page
     name: landing
@@ -4888,6 +5826,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/healers/sage/leveling-guide.md
     label: Leveling Guide
     name: leveling-guide
@@ -4944,6 +5896,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/healers/sage/basic-guide.md
     label: Basic Guide
     name: basic-guide
@@ -5000,6 +5966,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/healers/sage/skills-overview.md
     label: Skills Overview
     name: skills-overview
@@ -5056,6 +6036,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/healers/sage/openers.md
     label: Openers and Rotation
     name: openers
@@ -5108,6 +6102,20 @@ collections:
       - username
       - name
       value_field: username
+      widget: relation
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
       widget: relation
     file: content/jobs/healers/sage/faq.md
     label: Frequently Asked Questions
@@ -5165,6 +6173,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/healers/sage/advanced-guide.md
     label: Advanced Guide
     name: advanced-guide
@@ -5303,6 +6325,20 @@ collections:
       - name
       value_field: username
       widget: relation
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/healers/sage/stat-priority.md
     label: Stat Priority
     name: stat-priority
@@ -5350,6 +6386,20 @@ collections:
       - username
       - name
       value_field: username
+      widget: relation
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
       widget: relation
     file: content/jobs/healers/sage/job-changes.md
     label: Job Changes
@@ -5402,6 +6452,20 @@ collections:
       name: menu
       required: false
       widget: object
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/melee/monk/_index.md
     label: Landing page
     name: landing
@@ -5458,6 +6522,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/melee/monk/leveling-guide.md
     label: Leveling Guide
     name: leveling-guide
@@ -5514,6 +6592,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/melee/monk/basic-guide.md
     label: Basic Guide
     name: basic-guide
@@ -5570,6 +6662,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/melee/monk/skills-overview.md
     label: Skills Overview
     name: skills-overview
@@ -5626,6 +6732,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/melee/monk/openers.md
     label: Openers and Rotation
     name: openers
@@ -5678,6 +6798,20 @@ collections:
       - username
       - name
       value_field: username
+      widget: relation
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
       widget: relation
     file: content/jobs/melee/monk/faq.md
     label: Frequently Asked Questions
@@ -5735,6 +6869,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/melee/monk/advanced-guide.md
     label: Advanced Guide
     name: advanced-guide
@@ -5873,6 +7021,20 @@ collections:
       - name
       value_field: username
       widget: relation
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/melee/monk/stat-priority.md
     label: Stat Priority
     name: stat-priority
@@ -5920,6 +7082,20 @@ collections:
       - username
       - name
       value_field: username
+      widget: relation
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
       widget: relation
     file: content/jobs/melee/monk/job-changes.md
     label: Job Changes
@@ -5972,6 +7148,20 @@ collections:
       name: menu
       required: false
       widget: object
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/melee/dragoon/_index.md
     label: Landing page
     name: landing
@@ -6028,6 +7218,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/melee/dragoon/leveling-guide.md
     label: Leveling Guide
     name: leveling-guide
@@ -6084,6 +7288,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/melee/dragoon/basic-guide.md
     label: Basic Guide
     name: basic-guide
@@ -6140,6 +7358,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/melee/dragoon/skills-overview.md
     label: Skills Overview
     name: skills-overview
@@ -6196,6 +7428,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/melee/dragoon/openers.md
     label: Openers and Rotation
     name: openers
@@ -6248,6 +7494,20 @@ collections:
       - username
       - name
       value_field: username
+      widget: relation
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
       widget: relation
     file: content/jobs/melee/dragoon/faq.md
     label: Frequently Asked Questions
@@ -6305,6 +7565,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/melee/dragoon/advanced-guide.md
     label: Advanced Guide
     name: advanced-guide
@@ -6443,6 +7717,20 @@ collections:
       - name
       value_field: username
       widget: relation
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/melee/dragoon/stat-priority.md
     label: Stat Priority
     name: stat-priority
@@ -6490,6 +7778,20 @@ collections:
       - username
       - name
       value_field: username
+      widget: relation
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
       widget: relation
     file: content/jobs/melee/dragoon/job-changes.md
     label: Job Changes
@@ -6542,6 +7844,20 @@ collections:
       name: menu
       required: false
       widget: object
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/melee/ninja/_index.md
     label: Landing page
     name: landing
@@ -6598,6 +7914,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/melee/ninja/leveling-guide.md
     label: Leveling Guide
     name: leveling-guide
@@ -6654,6 +7984,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/melee/ninja/basic-guide.md
     label: Basic Guide
     name: basic-guide
@@ -6710,6 +8054,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/melee/ninja/skills-overview.md
     label: Skills Overview
     name: skills-overview
@@ -6766,6 +8124,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/melee/ninja/openers.md
     label: Openers and Rotation
     name: openers
@@ -6818,6 +8190,20 @@ collections:
       - username
       - name
       value_field: username
+      widget: relation
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
       widget: relation
     file: content/jobs/melee/ninja/faq.md
     label: Frequently Asked Questions
@@ -6875,6 +8261,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/melee/ninja/advanced-guide.md
     label: Advanced Guide
     name: advanced-guide
@@ -7013,6 +8413,20 @@ collections:
       - name
       value_field: username
       widget: relation
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/melee/ninja/stat-priority.md
     label: Stat Priority
     name: stat-priority
@@ -7060,6 +8474,20 @@ collections:
       - username
       - name
       value_field: username
+      widget: relation
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
       widget: relation
     file: content/jobs/melee/ninja/job-changes.md
     label: Job Changes
@@ -7112,6 +8540,20 @@ collections:
       name: menu
       required: false
       widget: object
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/melee/samurai/_index.md
     label: Landing page
     name: landing
@@ -7168,6 +8610,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/melee/samurai/leveling-guide.md
     label: Leveling Guide
     name: leveling-guide
@@ -7224,6 +8680,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/melee/samurai/basic-guide.md
     label: Basic Guide
     name: basic-guide
@@ -7280,6 +8750,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/melee/samurai/skills-overview.md
     label: Skills Overview
     name: skills-overview
@@ -7336,6 +8820,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/melee/samurai/openers.md
     label: Openers and Rotation
     name: openers
@@ -7388,6 +8886,20 @@ collections:
       - username
       - name
       value_field: username
+      widget: relation
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
       widget: relation
     file: content/jobs/melee/samurai/faq.md
     label: Frequently Asked Questions
@@ -7445,6 +8957,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/melee/samurai/advanced-guide.md
     label: Advanced Guide
     name: advanced-guide
@@ -7583,6 +9109,20 @@ collections:
       - name
       value_field: username
       widget: relation
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/melee/samurai/stat-priority.md
     label: Stat Priority
     name: stat-priority
@@ -7630,6 +9170,20 @@ collections:
       - username
       - name
       value_field: username
+      widget: relation
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
       widget: relation
     file: content/jobs/melee/samurai/job-changes.md
     label: Job Changes
@@ -7682,6 +9236,20 @@ collections:
       name: menu
       required: false
       widget: object
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/melee/reaper/_index.md
     label: Landing page
     name: landing
@@ -7738,6 +9306,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/melee/reaper/leveling-guide.md
     label: Leveling Guide
     name: leveling-guide
@@ -7794,6 +9376,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/melee/reaper/basic-guide.md
     label: Basic Guide
     name: basic-guide
@@ -7850,6 +9446,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/melee/reaper/skills-overview.md
     label: Skills Overview
     name: skills-overview
@@ -7906,6 +9516,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/melee/reaper/openers.md
     label: Openers and Rotation
     name: openers
@@ -7958,6 +9582,20 @@ collections:
       - username
       - name
       value_field: username
+      widget: relation
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
       widget: relation
     file: content/jobs/melee/reaper/faq.md
     label: Frequently Asked Questions
@@ -8015,6 +9653,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/melee/reaper/advanced-guide.md
     label: Advanced Guide
     name: advanced-guide
@@ -8153,6 +9805,20 @@ collections:
       - name
       value_field: username
       widget: relation
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/melee/reaper/stat-priority.md
     label: Stat Priority
     name: stat-priority
@@ -8200,6 +9866,20 @@ collections:
       - username
       - name
       value_field: username
+      widget: relation
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
       widget: relation
     file: content/jobs/melee/reaper/job-changes.md
     label: Job Changes
@@ -8252,6 +9932,20 @@ collections:
       name: menu
       required: false
       widget: object
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/ranged/bard/_index.md
     label: Landing page
     name: landing
@@ -8308,6 +10002,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/ranged/bard/leveling-guide.md
     label: Leveling Guide
     name: leveling-guide
@@ -8364,6 +10072,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/ranged/bard/basic-guide.md
     label: Basic Guide
     name: basic-guide
@@ -8420,6 +10142,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/ranged/bard/skills-overview.md
     label: Skills Overview
     name: skills-overview
@@ -8476,6 +10212,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/ranged/bard/openers.md
     label: Openers and Rotation
     name: openers
@@ -8528,6 +10278,20 @@ collections:
       - username
       - name
       value_field: username
+      widget: relation
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
       widget: relation
     file: content/jobs/ranged/bard/faq.md
     label: Frequently Asked Questions
@@ -8585,6 +10349,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/ranged/bard/advanced-guide.md
     label: Advanced Guide
     name: advanced-guide
@@ -8723,6 +10501,20 @@ collections:
       - name
       value_field: username
       widget: relation
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/ranged/bard/stat-priority.md
     label: Stat Priority
     name: stat-priority
@@ -8770,6 +10562,20 @@ collections:
       - username
       - name
       value_field: username
+      widget: relation
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
       widget: relation
     file: content/jobs/ranged/bard/job-changes.md
     label: Job Changes
@@ -8822,6 +10628,20 @@ collections:
       name: menu
       required: false
       widget: object
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/ranged/machinist/_index.md
     label: Landing page
     name: landing
@@ -8878,6 +10698,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/ranged/machinist/leveling-guide.md
     label: Leveling Guide
     name: leveling-guide
@@ -8934,6 +10768,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/ranged/machinist/basic-guide.md
     label: Basic Guide
     name: basic-guide
@@ -8990,6 +10838,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/ranged/machinist/skills-overview.md
     label: Skills Overview
     name: skills-overview
@@ -9046,6 +10908,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/ranged/machinist/openers.md
     label: Openers and Rotation
     name: openers
@@ -9098,6 +10974,20 @@ collections:
       - username
       - name
       value_field: username
+      widget: relation
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
       widget: relation
     file: content/jobs/ranged/machinist/faq.md
     label: Frequently Asked Questions
@@ -9155,6 +11045,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/ranged/machinist/advanced-guide.md
     label: Advanced Guide
     name: advanced-guide
@@ -9293,6 +11197,20 @@ collections:
       - name
       value_field: username
       widget: relation
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/ranged/machinist/stat-priority.md
     label: Stat Priority
     name: stat-priority
@@ -9340,6 +11258,20 @@ collections:
       - username
       - name
       value_field: username
+      widget: relation
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
       widget: relation
     file: content/jobs/ranged/machinist/job-changes.md
     label: Job Changes
@@ -9392,6 +11324,20 @@ collections:
       name: menu
       required: false
       widget: object
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/ranged/dancer/_index.md
     label: Landing page
     name: landing
@@ -9448,6 +11394,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/ranged/dancer/leveling-guide.md
     label: Leveling Guide
     name: leveling-guide
@@ -9504,6 +11464,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/ranged/dancer/basic-guide.md
     label: Basic Guide
     name: basic-guide
@@ -9560,6 +11534,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/ranged/dancer/skills-overview.md
     label: Skills Overview
     name: skills-overview
@@ -9616,6 +11604,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/ranged/dancer/openers.md
     label: Openers and Rotation
     name: openers
@@ -9668,6 +11670,20 @@ collections:
       - username
       - name
       value_field: username
+      widget: relation
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
       widget: relation
     file: content/jobs/ranged/dancer/faq.md
     label: Frequently Asked Questions
@@ -9725,6 +11741,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/ranged/dancer/advanced-guide.md
     label: Advanced Guide
     name: advanced-guide
@@ -9863,6 +11893,20 @@ collections:
       - name
       value_field: username
       widget: relation
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/ranged/dancer/stat-priority.md
     label: Stat Priority
     name: stat-priority
@@ -9910,6 +11954,20 @@ collections:
       - username
       - name
       value_field: username
+      widget: relation
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
       widget: relation
     file: content/jobs/ranged/dancer/job-changes.md
     label: Job Changes
@@ -9962,6 +12020,20 @@ collections:
       name: menu
       required: false
       widget: object
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/casters/black-mage/_index.md
     label: Landing page
     name: landing
@@ -10018,6 +12090,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/casters/black-mage/leveling-guide.md
     label: Leveling Guide
     name: leveling-guide
@@ -10074,6 +12160,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/casters/black-mage/basic-guide.md
     label: Basic Guide
     name: basic-guide
@@ -10130,6 +12230,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/casters/black-mage/skills-overview.md
     label: Skills Overview
     name: skills-overview
@@ -10186,6 +12300,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/casters/black-mage/openers.md
     label: Openers and Rotation
     name: openers
@@ -10238,6 +12366,20 @@ collections:
       - username
       - name
       value_field: username
+      widget: relation
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
       widget: relation
     file: content/jobs/casters/black-mage/faq.md
     label: Frequently Asked Questions
@@ -10295,6 +12437,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/casters/black-mage/advanced-guide.md
     label: Advanced Guide
     name: advanced-guide
@@ -10433,6 +12589,20 @@ collections:
       - name
       value_field: username
       widget: relation
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/casters/black-mage/stat-priority.md
     label: Stat Priority
     name: stat-priority
@@ -10480,6 +12650,20 @@ collections:
       - username
       - name
       value_field: username
+      widget: relation
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
       widget: relation
     file: content/jobs/casters/black-mage/job-changes.md
     label: Job Changes
@@ -10532,6 +12716,20 @@ collections:
       name: menu
       required: false
       widget: object
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/casters/red-mage/_index.md
     label: Landing page
     name: landing
@@ -10588,6 +12786,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/casters/red-mage/leveling-guide.md
     label: Leveling Guide
     name: leveling-guide
@@ -10644,6 +12856,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/casters/red-mage/basic-guide.md
     label: Basic Guide
     name: basic-guide
@@ -10700,6 +12926,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/casters/red-mage/skills-overview.md
     label: Skills Overview
     name: skills-overview
@@ -10756,6 +12996,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/casters/red-mage/openers.md
     label: Openers and Rotation
     name: openers
@@ -10808,6 +13062,20 @@ collections:
       - username
       - name
       value_field: username
+      widget: relation
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
       widget: relation
     file: content/jobs/casters/red-mage/faq.md
     label: Frequently Asked Questions
@@ -10865,6 +13133,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/casters/red-mage/advanced-guide.md
     label: Advanced Guide
     name: advanced-guide
@@ -11003,6 +13285,20 @@ collections:
       - name
       value_field: username
       widget: relation
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/casters/red-mage/stat-priority.md
     label: Stat Priority
     name: stat-priority
@@ -11050,6 +13346,20 @@ collections:
       - username
       - name
       value_field: username
+      widget: relation
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
       widget: relation
     file: content/jobs/casters/red-mage/job-changes.md
     label: Job Changes
@@ -11102,6 +13412,20 @@ collections:
       name: menu
       required: false
       widget: object
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/casters/summoner/_index.md
     label: Landing page
     name: landing
@@ -11158,6 +13482,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/casters/summoner/leveling-guide.md
     label: Leveling Guide
     name: leveling-guide
@@ -11214,6 +13552,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/casters/summoner/basic-guide.md
     label: Basic Guide
     name: basic-guide
@@ -11270,6 +13622,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/casters/summoner/skills-overview.md
     label: Skills Overview
     name: skills-overview
@@ -11326,6 +13692,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/casters/summoner/openers.md
     label: Openers and Rotation
     name: openers
@@ -11378,6 +13758,20 @@ collections:
       - username
       - name
       value_field: username
+      widget: relation
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
       widget: relation
     file: content/jobs/casters/summoner/faq.md
     label: Frequently Asked Questions
@@ -11435,6 +13829,20 @@ collections:
       required: false
       summary: '{{fields.date}}: {{fields.message}}'
       widget: list
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/casters/summoner/advanced-guide.md
     label: Advanced Guide
     name: advanced-guide
@@ -11573,6 +13981,20 @@ collections:
       - name
       value_field: username
       widget: relation
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
+      widget: relation
     file: content/jobs/casters/summoner/stat-priority.md
     label: Stat Priority
     name: stat-priority
@@ -11620,6 +14042,20 @@ collections:
       - username
       - name
       value_field: username
+      widget: relation
+    - label: SEO Description
+      name: seo-description
+      required: false
+      widget: string
+    - collection: seo-tags
+      label: SEO Tags (only the first six can be used)
+      multiple: true
+      name: tags
+      required: false
+      search_fields:
+      - tag
+      - description
+      value_field: tag
       widget: relation
     file: content/jobs/casters/summoner/job-changes.md
     label: Job Changes

--- a/scripts/.gitignore
+++ b/scripts/.gitignore
@@ -1,0 +1,3 @@
+# environment files
+env
+venv

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,11 @@
+# Useful Scripts
+
+## `generate_config.py`
+
+This script generates the yaml file used by netlify; as of right now, it only generates a config for a dev environment (production should be added at a later time).
+
+### Usage instructions
+
+1. (Optional) Create a virtualenv with `python -mvenv env && . /env/bin/activate` on Linux/Mac
+2. Install requirements: `pip install -r requirements.txt` 
+3. Generate a config with `python generate_config.py > ../exampleSite/static/admin/dev.yml`

--- a/scripts/generate_config.py
+++ b/scripts/generate_config.py
@@ -1,85 +1,68 @@
 import yaml
-from pprint import pprint
 
 from cgwain.collection import FileCollection, FolderCollection, File
-from cgwain.widgets import BooleanWidget, ColorWidget, DateTimeWidget, ImageWidget, ListWidget, MarkdownWidget, NumberWidget, ObjectWidget, RelationWidget, SelectWidget, StringWidget
-from cgwain.types import Widgets
+from cgwain.widgets import (
+    Widgets,
+    BooleanWidget,
+    ColorWidget,
+    DateTimeWidget,
+    ImageWidget,
+    ListWidget,
+    MarkdownWidget,
+    NumberWidget,
+    ObjectWidget,
+    RelationWidget,
+    SelectWidget,
+    StringWidget,
+)
 from cgwain.netlify import NetlifyConfig, Backend
 
-role_metadata = FolderCollection(
-    name='role-data',
-    label='Role Metadata',
-    folder='data/roles/',
-    format='json',
-    identifier_field='name',
-    create=True,
-    fields=[
-        StringWidget(label='Short name', name='title'),
-        StringWidget(label='Role name', name='name'),
-        NumberWidget(label='Display order', name='order'),
-        ColorWidget(label='Color', name='color'),
-        StringWidget(label='Icon', name='icon'),
-        StringWidget(label='Link', name='role_link'),
-        MarkdownWidget(label='Description', name='role_text_md'),
-        ListWidget(
-            label='Job Information',
-            name='jobs',
-            fields=[
-                StringWidget(label='Name', name='name'),
-                StringWidget(label='Link', name='job_link'),
-                StringWidget(label='Icon', name='icon'),
-            ]
-        )
-    ]
-)
 
-author_profile = FolderCollection(
-    name='author-profile',
-    label='Author Profile',
-    folder='data/author/',
-    format='json',
-    identifier_field='username',
-    media_folder='/static/img/profile',
-    public_folder='/img/profile',
-    create=True,
-    fields=[
-        StringWidget(name='username', label='Username'),
-        ImageWidget(name='image', label='Profile Image', choose_url=False),
-        StringWidget(name='name', label='Display Name'),
-        ObjectWidget(
-            name='socials',
-            label='Social Information',
-            fields=[
-                StringWidget(name='discord_id', label='Discord Name', required=False),
-            ]
-        )
-    ]
-)
+##
+# Common fields
+##
 
-
-title = StringWidget(name='title', label='Title')
-body = MarkdownWidget(name='body', label='Body')
+title = StringWidget(name="title", label="Title")
+body = MarkdownWidget(name="body", label="Body")
 title_and_body_widgets = [title, body]
 
-author_relation = RelationWidget(name='authors', label='Author(s)', required=False, multiple=True, collection='author-profile', search_fields=['username', 'name'], value_field='username', display_fields=['username', 'name'])
-
-lastmod = DateTimeWidget(name='lastmod', label='Last Updated', date_format='YYYY-MM-DD', time_format=False)
-
-changelog = ListWidget(
-    name='changelog',
-    label='Changelog Entry',
-    summary='{{fields.date}}: {{fields.message}}',
-    fields=[
-        DateTimeWidget(name='date', label='Date', date_format='YYYY-MM-DD', time_format=False),
-        StringWidget(name='message', label='Message')
-    ]
+author_relation = RelationWidget(
+    name="authors",
+    label="Author(s)",
+    required=False,
+    multiple=True,
+    collection="author-profile",
+    search_fields=["username", "name"],
+    value_field="username",
+    display_fields=["username", "name"],
 )
 
-patch = StringWidget(name='patch', label='Patch')
+lastmod = DateTimeWidget(
+    name="lastmod", label="Last Updated", date_format="YYYY-MM-DD", time_format=False
+)
+
+changelog = ListWidget(
+    name="changelog",
+    label="Changelog Entry",
+    summary="{{fields.date}}: {{fields.message}}",
+    fields=[
+        DateTimeWidget(
+            name="date", label="Date", date_format="YYYY-MM-DD", time_format=False
+        ),
+        StringWidget(name="message", label="Message"),
+    ],
+)
+
+patch = StringWidget(name="patch", label="Patch")
 
 common_fields: Widgets = [
     *title_and_body_widgets,
-    ImageWidget(name='card_header_image', label='Card Header Image', choose_url=False, required=False),
+    ImageWidget(
+        name="card_header_image",
+        label="Card Header Image",
+        choose_url=False,
+        required=False,
+    ),
     author_relation,
     patch,
     lastmod,
@@ -88,37 +71,42 @@ common_fields: Widgets = [
 ]
 qna_fields: Widgets = [
     title,
-    SelectWidget(name='layout', label='Layout', options=['qna'], default=['qna']),
+    SelectWidget(name="layout", label="Layout", options=["qna"], default=["qna"]),
     patch,
     lastmod,
     ListWidget(
-        name='qna',
-        label='FAQ Entry',
-        summary='{{fields.question}}: {{fields.answer}}',
+        name="qna",
+        label="FAQ Entry",
+        summary="{{fields.question}}: {{fields.answer}}",
         fields=[
-            StringWidget(name='question', label='Question'),
-            MarkdownWidget(name='answer', label='Answer'),
-        ]
+            StringWidget(name="question", label="Question"),
+            MarkdownWidget(name="answer", label="Answer"),
+        ],
     ),
     author_relation,
     # TODO: tags???
 ]
 bis_fields: Widgets = [
     title,
-    SelectWidget(name='layout', label='layout', options=['bis'], default=['bis']),
+    SelectWidget(name="layout", label="layout", options=["bis"], default=["bis"]),
     patch,
     lastmod,
     changelog,
     ListWidget(
-        name='bis',
-        label='Sets',
-        summary='{{fields.name}}',
+        name="bis",
+        label="Sets",
+        summary="{{fields.name}}",
         fields=[
-            StringWidget(name='name', label='Name'),
-            SelectWidget(name='type', label='Type', options=['etro', 'ariyala', 'gsheets', 'sleepyshiba'], default='etro'),
-            StringWidget(name='link', label='Link'),
-            MarkdownWidget(name='description', label='Description', required=False, default=''),
-        ]
+            StringWidget(name="name", label="Name"),
+            SelectWidget(
+                name="type",
+                label="Type",
+                options=["etro", "ariyala", "gsheets", "sleepyshiba"],
+                default="etro",
+            ),
+            StringWidget(name="link", label="Link"),
+            MarkdownWidget(name="description", label="Description", required=False),
+        ],
     ),
     author_relation,
 ]
@@ -128,237 +116,405 @@ stats: Widgets = [
     body,
     lastmod,
     changelog,
-    StringWidget(name='priority', label='Priority'),
+    StringWidget(name="priority", label="Priority"),
     author_relation,
     # TODO: tags???
 ]
 changes: Widgets = [
     title,
-    SelectWidget(name='layout', label='Layout', options=['changes'], default='changes'),
+    SelectWidget(name="layout", label="Layout", options=["changes"], default="changes"),
     lastmod,
     ListWidget(
-        name='changes',
-        label='Change',
-        summary='{{fields.patch}}',
+        name="changes",
+        label="Change",
+        summary="{{fields.patch}}",
         fields=[
-            StringWidget(name='patch', label='Patch'),
-            MarkdownWidget(name='description', label='Description'),
-        ]
+            StringWidget(name="patch", label="Patch"),
+            MarkdownWidget(name="description", label="Description"),
+        ],
     ),
     author_relation,
     # TODO: tags???
 ]
 
+##
+# Collections
+##
+
+role_metadata = FolderCollection(
+    name="role-data",
+    label="Role Metadata",
+    folder="data/roles/",
+    format="json",
+    identifier_field="name",
+    create=True,
+    fields=[
+        StringWidget(label="Short name", name="title"),
+        StringWidget(label="Role name", name="name"),
+        NumberWidget(label="Display order", name="order"),
+        ColorWidget(label="Color", name="color"),
+        StringWidget(label="Icon", name="icon"),
+        StringWidget(label="Link", name="role_link"),
+        MarkdownWidget(label="Description", name="role_text_md"),
+        ListWidget(
+            label="Job Information",
+            name="jobs",
+            fields=[
+                StringWidget(label="Name", name="name"),
+                StringWidget(label="Link", name="job_link"),
+                StringWidget(label="Icon", name="icon"),
+            ],
+        ),
+    ],
+)
+
+author_profile = FolderCollection(
+    name="author-profile",
+    label="Author Profile",
+    folder="data/author/",
+    format="json",
+    identifier_field="username",
+    media_folder="/static/img/profile",
+    public_folder="/img/profile",
+    create=True,
+    fields=[
+        StringWidget(name="username", label="Username"),
+        ImageWidget(name="image", label="Profile Image", choose_url=False),
+        StringWidget(name="name", label="Display Name"),
+        ObjectWidget(
+            name="socials",
+            label="Social Information",
+            fields=[
+                StringWidget(name="discord_id", label="Discord Name", required=False),
+            ],
+        ),
+    ],
+)
+
+
 def generate_role_landing_file(role: str) -> File:
+    """Generates the file for role landing"""
     role_proper = role.title()
     return File(
         name=role,
         label=role_proper,
-        media_folder=f'/static/img/jobs/{role}',
-        public_folder=f'/img/jobs/{role}',
-        file=f'content/jobs/{role}/_index.md',
+        media_folder=f"/static/img/jobs/{role}",
+        public_folder=f"/img/jobs/{role}",
+        file=f"content/jobs/{role}/_index.md",
         fields=[
             body,
             ObjectWidget(
-                name='menu',
-                label='Menu hierarchy',
+                name="menu",
+                label="Menu hierarchy",
                 fields=[
                     ObjectWidget(
-                        name='main',
-                        label='Main',
+                        name="main",
+                        label="Main",
                         fields=[
-                            SelectWidget(name='name', label='Name', options=[role_proper], default=role_proper),
-                            SelectWidget(name='identifier', label='Identifier', options=[role], default=[role]),
-                            SelectWidget(name='parent', label='Parent', options=['jobs'], default='jobs'),
-                        ]
+                            SelectWidget(
+                                name="name",
+                                label="Name",
+                                options=[role_proper],
+                                default=role_proper,
+                            ),
+                            SelectWidget(
+                                name="identifier",
+                                label="Identifier",
+                                options=[role],
+                                default=[role],
+                            ),
+                            SelectWidget(
+                                name="parent",
+                                label="Parent",
+                                options=["jobs"],
+                                default="jobs",
+                            ),
+                        ],
                     )
-                ]
+                ],
             ),
-            SelectWidget(name='role', label='Role', options=[role], default=role),
-            SelectWidget(name='layout', label='Layout', options=['role_home'], default='role_home'),
-            ImageWidget(name='bg_header_image', label='Background Header Image', choose_url=False),
-            ImageWidget(name='role_hero_image', label='Role Hero Image', choose_url=False),
-        ]
+            SelectWidget(name="role", label="Role", options=[role], default=role),
+            SelectWidget(
+                name="layout",
+                label="Layout",
+                options=["role_home"],
+                default="role_home",
+            ),
+            ImageWidget(
+                name="bg_header_image",
+                label="Background Header Image",
+                choose_url=False,
+            ),
+            ImageWidget(
+                name="role_hero_image", label="Role Hero Image", choose_url=False
+            ),
+        ],
     )
 
+
 def generate_job_guide(job_name: str, job_short_name: str, role: str) -> FileCollection:
-    job_slug = job_name.lower().replace(' ', '-')
+    """Generates the general job guide file collection
+
+    :param job_name: The job name, such as "Dark Knight"
+    :type job_name: str
+    :param job_short_name: The 'short' job name, such as "drk"
+    :type job_short_name: str
+    :param role: The job role, such as "Healers", or "Tanks"
+    :type role: str
+
+    :return: A FileCollection with all the page(s) standard to the job guide
+    :rtype: FileCollection
+    """
+    job_slug = job_name.lower().replace(" ", "-")
     return FileCollection(
-        name=f'{job_short_name}-guide',
-        label=f'{job_name} guide',
-        media_folder=f'/static/img/jobs/{job_short_name}',
-        public_folder=f'/img/jobs/{job_short_name}',
+        name=f"{job_short_name}-guide",
+        label=f"{job_name} guide",
+        media_folder=f"/static/img/jobs/{job_short_name}",
+        public_folder=f"/img/jobs/{job_short_name}",
         files=[
             File(
-                name='landing',
-                label='Landing page',
-                file=f'content/jobs/tanks/{job_slug}/_index.md',
+                name="landing",
+                label="Landing page",
+                file=f"content/jobs/tanks/{job_slug}/_index.md",
                 fields=[
                     *title_and_body_widgets,
-                    SelectWidget(name='job_name', label='Job Name', options=[job_name.lower()], default=[job_name.lower()]),
+                    SelectWidget(
+                        name="job_name",
+                        label="Job Name",
+                        options=[job_name.lower()],
+                        default=[job_name.lower()],
+                    ),
                     ObjectWidget(
-                        name='menu',
-                        label='Menu hierarchy',
+                        name="menu",
+                        label="Menu hierarchy",
                         fields=[
                             ObjectWidget(
-                                name='main',
-                                label='Main',
+                                name="main",
+                                label="Main",
                                 fields=[
-                                    SelectWidget(name='name', label='Name', options=[job_name], default=[job_name]),
-                                    SelectWidget(name='parent', label='Parent', options=[role], default=[role])
-                                ]
+                                    SelectWidget(
+                                        name="name",
+                                        label="Name",
+                                        options=[job_name],
+                                        default=[job_name],
+                                    ),
+                                    SelectWidget(
+                                        name="parent",
+                                        label="Parent",
+                                        options=[role],
+                                        default=[role],
+                                    ),
+                                ],
                             )
-                        ]
+                        ],
                     ),
                     # TODO: tags???
-                ]
+                ],
             ),
             File(
-                name='leveling-guide',
-                label='Leveling Guide',
-                file=f'content/jobs/{role}/{job_slug}/leveling-guide.md',
-                fields=common_fields
-            ),
-            File(
-                name='basic-guide',
-                label='Basic Guide',
-                file=f'content/jobs/{role}/{job_slug}/basic-guide.md',
-                fields=common_fields
-            ),
-            File(
-                name='skills-overview',
-                label='Skills Overview',
-                file=f'content/jobs/{role}/{job_slug}/skills-overview.md',
-                fields=common_fields
-            ),
-            File(
-                name='openers',
-                label='Openers and Rotation',
-                file=f'content/jobs/{role}/{job_slug}/openers.md',
-                fields=common_fields
-            ),
-            File(
-                name='faq',
-                label='Frequently Asked Questions',
-                file=f'content/jobs/{role}/{job_slug}/faq.md',
-                fields=qna_fields,
-            ),
-            File(
-                name='advanced-guide',
-                label='Advanced Guide',
-                file=f'content/jobs/{role}/{job_slug}/advanced-guide.md',
+                name="leveling-guide",
+                label="Leveling Guide",
+                file=f"content/jobs/{role}/{job_slug}/leveling-guide.md",
                 fields=common_fields,
             ),
             File(
-                name='bis',
-                label='Best in Slot',
-                file=f'content/jobs/{role}/{job_slug}/best-in-slot.md',
+                name="basic-guide",
+                label="Basic Guide",
+                file=f"content/jobs/{role}/{job_slug}/basic-guide.md",
+                fields=common_fields,
+            ),
+            File(
+                name="skills-overview",
+                label="Skills Overview",
+                file=f"content/jobs/{role}/{job_slug}/skills-overview.md",
+                fields=common_fields,
+            ),
+            File(
+                name="openers",
+                label="Openers and Rotation",
+                file=f"content/jobs/{role}/{job_slug}/openers.md",
+                fields=common_fields,
+            ),
+            File(
+                name="faq",
+                label="Frequently Asked Questions",
+                file=f"content/jobs/{role}/{job_slug}/faq.md",
+                fields=qna_fields,
+            ),
+            File(
+                name="advanced-guide",
+                label="Advanced Guide",
+                file=f"content/jobs/{role}/{job_slug}/advanced-guide.md",
+                fields=common_fields,
+            ),
+            File(
+                name="bis",
+                label="Best in Slot",
+                file=f"content/jobs/{role}/{job_slug}/best-in-slot.md",
                 fields=bis_fields,
             ),
             File(
-                name='stat-priority',
-                label='Stat Priority',
-                file=f'content/jobs/{role}/{job_slug}/stat-priority.md',
+                name="stat-priority",
+                label="Stat Priority",
+                file=f"content/jobs/{role}/{job_slug}/stat-priority.md",
                 fields=stats,
             ),
             File(
-                name='job-changes',
-                label='Job Changes',
-                file=f'content/jobs/{role}/{job_slug}/job-changes.md',
+                name="job-changes",
+                label="Job Changes",
+                file=f"content/jobs/{role}/{job_slug}/job-changes.md",
                 fields=changes,
             ),
-        ]
+        ],
     )
+
 
 def generate_encounter_for(name: str, tier: str) -> FolderCollection:
     """Generates a FolderCollection for a given encounter
 
     :param name: The name of the encounter. For alex, you'd submit 'Alexander'
+    :param name: str
     :param tier: Is one of 'savage', 'ultimate', or 'extreme'
+    :param tier: str
     :return: A FolderCollection for the encounter
+    :rtype: FolderCollection
     """
     identifier = name.lower()
     return FolderCollection(
-        name=f'encounter-{identifier}',
+        name=f"encounter-{identifier}",
         label=identifier,
-        folder=f'content/encounters/{tier}/{identifier}',
-        media_folder=f'/static/img/encounters/{tier}/{identifier}',
-        public_folder=f'/img/encounters/{tier}/{identifier}',
-        identifier_field='fight_title',
+        folder=f"content/encounters/{tier}/{identifier}",
+        media_folder=f"/static/img/encounters/{tier}/{identifier}",
+        public_folder=f"/img/encounters/{tier}/{identifier}",
+        identifier_field="fight_title",
         create=True,
         fields=[
-            StringWidget(name='title', label='Fight Name', hint='This is the fight name (Ex. "E12 (Eternity)" or "O12 (Alphascape 4.0)")'),
-            StringWidget(name='fight_title', label='Short Name of Fight', hint='This is the short name of the fight (Ex. "o12s" or "e12s-p2")'), # TODO: pattern
-            SelectWidget(name='difficulty', label='Encounter Category', options=["savage", "ultimate", "extreme"]),
-            ImageWidget(name='card_image', label='Fight Card Image', choose_url=False),
-            ImageWidget(name='banner_image', label='Fight Banner (for individual guides)', choose_url=False),
-            ImageWidget(name='tier_image', label='Encounter Tier Image', choose_url=False, required=False),
-            StringWidget(name='tier_name', label='Encounter Tier Name', hint='''Please capitalize the name (Ex. "Eden's Promise" or "Alphascape")'''),
-            StringWidget(name='series_name', label='Encounter Series Name (Capitalized)', hint='Please capitalize the series name (Ex. "Eden Series" or "Alexander Series")'),
-            NumberWidget(name='weight', label='Weight', hint='(1 - last fight of tier, 2 - third fight of tier, etc. Must be in reverse order.)'),
-            NumberWidget(name='tier_weight', label='Tier Weight', hint='(1 - EW, 2 - ShB, 3 - SB, 4 - HW, 5 - ARR)'),
-            BooleanWidget(name='coming_soon', label='Coming Soon?', hint='This adds the coming soon overlay. Only enable Coming Soon or Spoilers. Not both.', required=False),
-            BooleanWidget(name='spoilers', label='Spoilers?', hint='This adds the spoiler overlay. Only enable Coming Soon or Spoilers. Not both.', required=False),
-            SelectWidget(name='expansion', label='Expansion', options=["ew", "shb", "sb", "hw", "arr"]),
+            StringWidget(
+                name="title",
+                label="Fight Name",
+                hint='This is the fight name (Ex. "E12 (Eternity)" or "O12 (Alphascape 4.0)")',
+            ),
+            StringWidget(
+                name="fight_title",
+                label="Short Name of Fight",
+                hint='This is the short name of the fight (Ex. "o12s" or "e12s-p2")',
+            ),  # TODO: pattern
+            SelectWidget(
+                name="difficulty",
+                label="Encounter Category",
+                options=["savage", "ultimate", "extreme"],
+            ),
+            ImageWidget(name="card_image", label="Fight Card Image", choose_url=False),
+            ImageWidget(
+                name="banner_image",
+                label="Fight Banner (for individual guides)",
+                choose_url=False,
+            ),
+            ImageWidget(
+                name="tier_image",
+                label="Encounter Tier Image",
+                choose_url=False,
+                required=False,
+            ),
+            StringWidget(
+                name="tier_name",
+                label="Encounter Tier Name",
+                hint="""Please capitalize the name (Ex. "Eden's Promise" or "Alphascape")""",
+            ),
+            StringWidget(
+                name="series_name",
+                label="Encounter Series Name (Capitalized)",
+                hint='Please capitalize the series name (Ex. "Eden Series" or "Alexander Series")',
+            ),
+            NumberWidget(
+                name="weight",
+                label="Weight",
+                hint="(1 - last fight of tier, 2 - third fight of tier, etc. Must be in reverse order.)",
+            ),
+            NumberWidget(
+                name="tier_weight",
+                label="Tier Weight",
+                hint="(1 - EW, 2 - ShB, 3 - SB, 4 - HW, 5 - ARR)",
+            ),
+            BooleanWidget(
+                name="coming_soon",
+                label="Coming Soon?",
+                hint="This adds the coming soon overlay. Only enable Coming Soon or Spoilers. Not both.",
+                required=False,
+            ),
+            BooleanWidget(
+                name="spoilers",
+                label="Spoilers?",
+                hint="This adds the spoiler overlay. Only enable Coming Soon or Spoilers. Not both.",
+                required=False,
+            ),
+            SelectWidget(
+                name="expansion",
+                label="Expansion",
+                options=["ew", "shb", "sb", "hw", "arr"],
+            ),
             body,
             author_relation,
             lastmod,
             patch,
             changelog,
             # TODO: tags???
-        ]
+        ],
     )
+
 
 netlify = NetlifyConfig(
     backend=Backend(
-        name='git-gateway',
+        name="git-gateway",
     ),
     local_backend=True,
-    media_folder='static/img',
-    public_folder='/img',
+    media_folder="static/img",
+    public_folder="/img",
     collections=[
         role_metadata,
         author_profile,
         FileCollection(
-            name='role-landing',
-            label='Role Landing Pages',
+            name="role-landing",
+            label="Role Landing Pages",
             files=[
-                generate_role_landing_file('tanks'),
-                generate_role_landing_file('healers'),
-                generate_role_landing_file('melee'),
-                generate_role_landing_file('ranged'),
-                generate_role_landing_file('casters')
-            ]
+                generate_role_landing_file("tanks"),
+                generate_role_landing_file("healers"),
+                generate_role_landing_file("melee"),
+                generate_role_landing_file("ranged"),
+                generate_role_landing_file("casters"),
+            ],
         ),
-        generate_encounter_for(name='Pandaemonium', tier='savage'),
-        generate_encounter_for(name='Ultimates', tier='ultimate'),
-        generate_encounter_for(name='Extreme', tier='extreme'), # TODO: this presents a problem with naming in the function
+        generate_encounter_for(name="Pandaemonium", tier="savage"),
+        generate_encounter_for(name="Ultimates", tier="ultimate"),
+        generate_encounter_for(
+            name="Extreme", tier="extreme"
+        ),  # TODO: this presents a problem with naming in the function
         # tanks
-        generate_job_guide('Paladin', 'pld', 'tanks'),
+        generate_job_guide("Paladin", "pld", "tanks"),
         # TODO: fight tips per job
-        generate_job_guide('Warrior', 'war', 'tanks'),
-        generate_job_guide('Dark Knight', 'drk', 'tanks'),
-        generate_job_guide('Gunbreaker', 'gbn', 'tanks'),
+        generate_job_guide("Warrior", "war", "tanks"),
+        generate_job_guide("Dark Knight", "drk", "tanks"),
+        generate_job_guide("Gunbreaker", "gbn", "tanks"),
         # healers
-        generate_job_guide('Scholar', 'sch', 'healers'),
-        generate_job_guide('White Mage', 'whm', 'healers'),
-        generate_job_guide('Astrologian', 'ast', 'healers'),
-        generate_job_guide('Sage', 'sge', 'healers'),
+        generate_job_guide("Scholar", "sch", "healers"),
+        generate_job_guide("White Mage", "whm", "healers"),
+        generate_job_guide("Astrologian", "ast", "healers"),
+        generate_job_guide("Sage", "sge", "healers"),
         # melee
-        generate_job_guide('Monk', 'mnk', 'melee'),
-        generate_job_guide('Dragoon', 'drg', 'melee'),
-        generate_job_guide('Ninja', 'nin', 'melee'),
-        generate_job_guide('Samurai', 'sam', 'melee'),
-        generate_job_guide('Reaper', 'rpr', 'melee'),
+        generate_job_guide("Monk", "mnk", "melee"),
+        generate_job_guide("Dragoon", "drg", "melee"),
+        generate_job_guide("Ninja", "nin", "melee"),
+        generate_job_guide("Samurai", "sam", "melee"),
+        generate_job_guide("Reaper", "rpr", "melee"),
         # ranged
-        generate_job_guide('Bard', 'brd', 'ranged'),
-        generate_job_guide('Machinist', 'mch', 'ranged'),
-        generate_job_guide('Dancer', 'dnc', 'ranged'),
+        generate_job_guide("Bard", "brd", "ranged"),
+        generate_job_guide("Machinist", "mch", "ranged"),
+        generate_job_guide("Dancer", "dnc", "ranged"),
         # casters
-        generate_job_guide('Black Mage', 'blm', 'casters'),
-        generate_job_guide('Red Mage', 'rdm', 'casters'),
-        generate_job_guide('Summoner', 'smn', 'casters'),
-    ]
+        generate_job_guide("Black Mage", "blm", "casters"),
+        generate_job_guide("Red Mage", "rdm", "casters"),
+        generate_job_guide("Summoner", "smn", "casters"),
+    ],
 )
 
 print(yaml.dump(netlify.dict()))

--- a/scripts/generate_config.py
+++ b/scripts/generate_config.py
@@ -275,7 +275,7 @@ def generate_job_guide(job_name: str, job_short_name: str, role: str) -> FileCol
             File(
                 name="landing",
                 label="Landing page",
-                file=f"content/jobs/tanks/{job_slug}/_index.md",
+                file=f"content/jobs/{role}/{job_slug}/_index.md",
                 fields=[
                     *title_and_body_widgets,
                     SelectWidget(

--- a/scripts/generate_config.py
+++ b/scripts/generate_config.py
@@ -1,0 +1,364 @@
+import yaml
+from pprint import pprint
+
+from cgwain.collection import FileCollection, FolderCollection, File
+from cgwain.widgets import BooleanWidget, ColorWidget, DateTimeWidget, ImageWidget, ListWidget, MarkdownWidget, NumberWidget, ObjectWidget, RelationWidget, SelectWidget, StringWidget
+from cgwain.types import Widgets
+from cgwain.netlify import NetlifyConfig, Backend
+
+role_metadata = FolderCollection(
+    name='role-data',
+    label='Role Metadata',
+    folder='data/roles/',
+    format='json',
+    identifier_field='name',
+    create=True,
+    fields=[
+        StringWidget(label='Short name', name='title'),
+        StringWidget(label='Role name', name='name'),
+        NumberWidget(label='Display order', name='order'),
+        ColorWidget(label='Color', name='color'),
+        StringWidget(label='Icon', name='icon'),
+        StringWidget(label='Link', name='role_link'),
+        MarkdownWidget(label='Description', name='role_text_md'),
+        ListWidget(
+            label='Job Information',
+            name='jobs',
+            fields=[
+                StringWidget(label='Name', name='name'),
+                StringWidget(label='Link', name='job_link'),
+                StringWidget(label='Icon', name='icon'),
+            ]
+        )
+    ]
+)
+
+author_profile = FolderCollection(
+    name='author-profile',
+    label='Author Profile',
+    folder='data/author/',
+    format='json',
+    identifier_field='username',
+    media_folder='/static/img/profile',
+    public_folder='/img/profile',
+    create=True,
+    fields=[
+        StringWidget(name='username', label='Username'),
+        ImageWidget(name='image', label='Profile Image', choose_url=False),
+        StringWidget(name='name', label='Display Name'),
+        ObjectWidget(
+            name='socials',
+            label='Social Information',
+            fields=[
+                StringWidget(name='discord_id', label='Discord Name', required=False),
+            ]
+        )
+    ]
+)
+
+
+title = StringWidget(name='title', label='Title')
+body = MarkdownWidget(name='body', label='Body')
+title_and_body_widgets = [title, body]
+
+author_relation = RelationWidget(name='authors', label='Author(s)', required=False, multiple=True, collection='author-profile', search_fields=['username', 'name'], value_field='username', display_fields=['username', 'name'])
+
+lastmod = DateTimeWidget(name='lastmod', label='Last Updated', date_format='YYYY-MM-DD', time_format=False)
+
+changelog = ListWidget(
+    name='changelog',
+    label='Changelog Entry',
+    summary='{{fields.date}}: {{fields.message}}',
+    fields=[
+        DateTimeWidget(name='date', label='Date', date_format='YYYY-MM-DD', time_format=False),
+        StringWidget(name='message', label='Message')
+    ]
+)
+
+patch = StringWidget(name='patch', label='Patch')
+
+common_fields: Widgets = [
+    *title_and_body_widgets,
+    ImageWidget(name='card_header_image', label='Card Header Image', choose_url=False, required=False),
+    author_relation,
+    patch,
+    lastmod,
+    changelog,
+    # TODO: tags???
+]
+qna_fields: Widgets = [
+    title,
+    SelectWidget(name='layout', label='Layout', options=['qna'], default=['qna']),
+    patch,
+    lastmod,
+    ListWidget(
+        name='qna',
+        label='FAQ Entry',
+        summary='{{fields.question}}: {{fields.answer}}',
+        fields=[
+            StringWidget(name='question', label='Question'),
+            MarkdownWidget(name='answer', label='Answer'),
+        ]
+    ),
+    author_relation,
+    # TODO: tags???
+]
+bis_fields: Widgets = [
+    title,
+    SelectWidget(name='layout', label='layout', options=['bis'], default=['bis']),
+    patch,
+    lastmod,
+    changelog,
+    ListWidget(
+        name='bis',
+        label='Sets',
+        summary='{{fields.name}}',
+        fields=[
+            StringWidget(name='name', label='Name'),
+            SelectWidget(name='type', label='Type', options=['etro', 'ariyala', 'gsheets', 'sleepyshiba'], default='etro'),
+            StringWidget(name='link', label='Link'),
+            MarkdownWidget(name='description', label='Description', required=False, default=''),
+        ]
+    ),
+    author_relation,
+]
+stats: Widgets = [
+    title,
+    patch,
+    body,
+    lastmod,
+    changelog,
+    StringWidget(name='priority', label='Priority'),
+    author_relation,
+    # TODO: tags???
+]
+changes: Widgets = [
+    title,
+    SelectWidget(name='layout', label='Layout', options=['changes'], default='changes'),
+    lastmod,
+    ListWidget(
+        name='changes',
+        label='Change',
+        summary='{{fields.patch}}',
+        fields=[
+            StringWidget(name='patch', label='Patch'),
+            MarkdownWidget(name='description', label='Description'),
+        ]
+    ),
+    author_relation,
+    # TODO: tags???
+]
+
+def generate_role_landing_file(role: str) -> File:
+    role_proper = role.title()
+    return File(
+        name=role,
+        label=role_proper,
+        media_folder=f'/static/img/jobs/{role}',
+        public_folder=f'/img/jobs/{role}',
+        file=f'content/jobs/{role}/_index.md',
+        fields=[
+            body,
+            ObjectWidget(
+                name='menu',
+                label='Menu hierarchy',
+                fields=[
+                    ObjectWidget(
+                        name='main',
+                        label='Main',
+                        fields=[
+                            SelectWidget(name='name', label='Name', options=[role_proper], default=role_proper),
+                            SelectWidget(name='identifier', label='Identifier', options=[role], default=[role]),
+                            SelectWidget(name='parent', label='Parent', options=['jobs'], default='jobs'),
+                        ]
+                    )
+                ]
+            ),
+            SelectWidget(name='role', label='Role', options=[role], default=role),
+            SelectWidget(name='layout', label='Layout', options=['role_home'], default='role_home'),
+            ImageWidget(name='bg_header_image', label='Background Header Image', choose_url=False),
+            ImageWidget(name='role_hero_image', label='Role Hero Image', choose_url=False),
+        ]
+    )
+
+def generate_job_guide(job_name: str, job_short_name: str, role: str) -> FileCollection:
+    job_slug = job_name.lower().replace(' ', '-')
+    return FileCollection(
+        name=f'{job_short_name}-guide',
+        label=f'{job_name} guide',
+        media_folder=f'/static/img/jobs/{job_short_name}',
+        public_folder=f'/img/jobs/{job_short_name}',
+        files=[
+            File(
+                name='landing',
+                label='Landing page',
+                file=f'content/jobs/tanks/{job_slug}/_index.md',
+                fields=[
+                    *title_and_body_widgets,
+                    SelectWidget(name='job_name', label='Job Name', options=[job_name.lower()], default=[job_name.lower()]),
+                    ObjectWidget(
+                        name='menu',
+                        label='Menu hierarchy',
+                        fields=[
+                            ObjectWidget(
+                                name='main',
+                                label='Main',
+                                fields=[
+                                    SelectWidget(name='name', label='Name', options=[job_name], default=[job_name]),
+                                    SelectWidget(name='parent', label='Parent', options=[role], default=[role])
+                                ]
+                            )
+                        ]
+                    ),
+                    # TODO: tags???
+                ]
+            ),
+            File(
+                name='leveling-guide',
+                label='Leveling Guide',
+                file=f'content/jobs/{role}/{job_slug}/leveling-guide.md',
+                fields=common_fields
+            ),
+            File(
+                name='basic-guide',
+                label='Basic Guide',
+                file=f'content/jobs/{role}/{job_slug}/basic-guide.md',
+                fields=common_fields
+            ),
+            File(
+                name='skills-overview',
+                label='Skills Overview',
+                file=f'content/jobs/{role}/{job_slug}/skills-overview.md',
+                fields=common_fields
+            ),
+            File(
+                name='openers',
+                label='Openers and Rotation',
+                file=f'content/jobs/{role}/{job_slug}/openers.md',
+                fields=common_fields
+            ),
+            File(
+                name='faq',
+                label='Frequently Asked Questions',
+                file=f'content/jobs/{role}/{job_slug}/faq.md',
+                fields=qna_fields,
+            ),
+            File(
+                name='advanced-guide',
+                label='Advanced Guide',
+                file=f'content/jobs/{role}/{job_slug}/advanced-guide.md',
+                fields=common_fields,
+            ),
+            File(
+                name='bis',
+                label='Best in Slot',
+                file=f'content/jobs/{role}/{job_slug}/best-in-slot.md',
+                fields=bis_fields,
+            ),
+            File(
+                name='stat-priority',
+                label='Stat Priority',
+                file=f'content/jobs/{role}/{job_slug}/stat-priority.md',
+                fields=stats,
+            ),
+            File(
+                name='job-changes',
+                label='Job Changes',
+                file=f'content/jobs/{role}/{job_slug}/job-changes.md',
+                fields=changes,
+            ),
+        ]
+    )
+
+def generate_encounter_for(name: str, tier: str) -> FolderCollection:
+    """Generates a FolderCollection for a given encounter
+
+    :param name: The name of the encounter. For alex, you'd submit 'Alexander'
+    :param tier: Is one of 'savage', 'ultimate', or 'extreme'
+    :return: A FolderCollection for the encounter
+    """
+    identifier = name.lower()
+    return FolderCollection(
+        name=f'encounter-{identifier}',
+        label=identifier,
+        folder=f'content/encounters/{tier}/{identifier}',
+        media_folder=f'/static/img/encounters/{tier}/{identifier}',
+        public_folder=f'/img/encounters/{tier}/{identifier}',
+        identifier_field='fight_title',
+        create=True,
+        fields=[
+            StringWidget(name='title', label='Fight Name', hint='This is the fight name (Ex. "E12 (Eternity)" or "O12 (Alphascape 4.0)")'),
+            StringWidget(name='fight_title', label='Short Name of Fight', hint='This is the short name of the fight (Ex. "o12s" or "e12s-p2")'), # TODO: pattern
+            SelectWidget(name='difficulty', label='Encounter Category', options=["savage", "ultimate", "extreme"]),
+            ImageWidget(name='card_image', label='Fight Card Image', choose_url=False),
+            ImageWidget(name='banner_image', label='Fight Banner (for individual guides)', choose_url=False),
+            ImageWidget(name='tier_image', label='Encounter Tier Image', choose_url=False, required=False),
+            StringWidget(name='tier_name', label='Encounter Tier Name', hint='''Please capitalize the name (Ex. "Eden's Promise" or "Alphascape")'''),
+            StringWidget(name='series_name', label='Encounter Series Name (Capitalized)', hint='Please capitalize the series name (Ex. "Eden Series" or "Alexander Series")'),
+            NumberWidget(name='weight', label='Weight', hint='(1 - last fight of tier, 2 - third fight of tier, etc. Must be in reverse order.)'),
+            NumberWidget(name='tier_weight', label='Tier Weight', hint='(1 - EW, 2 - ShB, 3 - SB, 4 - HW, 5 - ARR)'),
+            BooleanWidget(name='coming_soon', label='Coming Soon?', hint='This adds the coming soon overlay. Only enable Coming Soon or Spoilers. Not both.', required=False),
+            BooleanWidget(name='spoilers', label='Spoilers?', hint='This adds the spoiler overlay. Only enable Coming Soon or Spoilers. Not both.', required=False),
+            SelectWidget(name='expansion', label='Expansion', options=["ew", "shb", "sb", "hw", "arr"]),
+            body,
+            author_relation,
+            lastmod,
+            patch,
+            changelog,
+            # TODO: tags???
+        ]
+    )
+
+netlify = NetlifyConfig(
+    backend=Backend(
+        name='git-gateway',
+    ),
+    local_backend=True,
+    media_folder='static/img',
+    public_folder='/img',
+    collections=[
+        role_metadata,
+        author_profile,
+        FileCollection(
+            name='role-landing',
+            label='Role Landing Pages',
+            files=[
+                generate_role_landing_file('tanks'),
+                generate_role_landing_file('healers'),
+                generate_role_landing_file('melee'),
+                generate_role_landing_file('ranged'),
+                generate_role_landing_file('casters')
+            ]
+        ),
+        generate_encounter_for(name='Pandaemonium', tier='savage'),
+        generate_encounter_for(name='Ultimates', tier='ultimate'),
+        generate_encounter_for(name='Extreme', tier='extreme'), # TODO: this presents a problem with naming in the function
+        # tanks
+        generate_job_guide('Paladin', 'pld', 'tanks'),
+        # TODO: fight tips per job
+        generate_job_guide('Warrior', 'war', 'tanks'),
+        generate_job_guide('Dark Knight', 'drk', 'tanks'),
+        generate_job_guide('Gunbreaker', 'gbn', 'tanks'),
+        # healers
+        generate_job_guide('Scholar', 'sch', 'healers'),
+        generate_job_guide('White Mage', 'whm', 'healers'),
+        generate_job_guide('Astrologian', 'ast', 'healers'),
+        generate_job_guide('Sage', 'sge', 'healers'),
+        # melee
+        generate_job_guide('Monk', 'mnk', 'melee'),
+        generate_job_guide('Dragoon', 'drg', 'melee'),
+        generate_job_guide('Ninja', 'nin', 'melee'),
+        generate_job_guide('Samurai', 'sam', 'melee'),
+        generate_job_guide('Reaper', 'rpr', 'melee'),
+        # ranged
+        generate_job_guide('Bard', 'brd', 'ranged'),
+        generate_job_guide('Machinist', 'mch', 'ranged'),
+        generate_job_guide('Dancer', 'dnc', 'ranged'),
+        # casters
+        generate_job_guide('Black Mage', 'blm', 'casters'),
+        generate_job_guide('Red Mage', 'rdm', 'casters'),
+        generate_job_guide('Summoner', 'smn', 'casters'),
+    ]
+)
+
+print(yaml.dump(netlify.dict()))

--- a/scripts/generate_config.py
+++ b/scripts/generate_config.py
@@ -53,7 +53,7 @@ changelog = ListWidget(
     ],
 )
 
-seo_description = StringWidget(name="seo-description", label="SEO Description")
+seo_description = StringWidget(name="description", label="SEO Description")
 seo_tag_relation = RelationWidget(
     name="tags",
     label="SEO Tags (only the first six can be used)",

--- a/scripts/generate_config.py
+++ b/scripts/generate_config.py
@@ -53,6 +53,16 @@ changelog = ListWidget(
     ],
 )
 
+seo_description = StringWidget(name="seo-description", label="SEO Description")
+seo_tag_relation = RelationWidget(
+    name="tags",
+    label="SEO Tags (only the first six can be used)",
+    multiple=True,
+    collection="seo-tags",
+    search_fields=["tag", "description"],
+    value_field="tag",
+)
+
 patch = StringWidget(name="patch", label="Patch")
 
 common_fields: Widgets = [
@@ -67,7 +77,8 @@ common_fields: Widgets = [
     patch,
     lastmod,
     changelog,
-    # TODO: tags???
+    seo_description,
+    seo_tag_relation,
 ]
 qna_fields: Widgets = [
     title,
@@ -84,7 +95,8 @@ qna_fields: Widgets = [
         ],
     ),
     author_relation,
-    # TODO: tags???
+    seo_description,
+    seo_tag_relation,
 ]
 bis_fields: Widgets = [
     title,
@@ -118,7 +130,8 @@ stats: Widgets = [
     changelog,
     StringWidget(name="priority", label="Priority"),
     author_relation,
-    # TODO: tags???
+    seo_description,
+    seo_tag_relation,
 ]
 changes: Widgets = [
     title,
@@ -134,7 +147,8 @@ changes: Widgets = [
         ],
     ),
     author_relation,
-    # TODO: tags???
+    seo_description,
+    seo_tag_relation,
 ]
 
 ##
@@ -188,6 +202,20 @@ author_profile = FolderCollection(
                 StringWidget(name="discord_id", label="Discord Name", required=False),
             ],
         ),
+    ],
+)
+
+seo_tag_collection = FolderCollection(
+    name="seo-tags",
+    folder="data/seo/tags",
+    format="json",
+    identifier_field="tag",
+    media_folder="/static/img/profile",
+    public_folder="/img/profile",
+    create=True,
+    fields=[
+        StringWidget(name="tag", label="Tag"),
+        StringWidget(name="description", label="Description"),
     ],
 )
 
@@ -308,7 +336,8 @@ def generate_job_guide(job_name: str, job_short_name: str, role: str) -> FileCol
                             )
                         ],
                     ),
-                    # TODO: tags???
+                    seo_description,
+                    seo_tag_relation,
                 ],
             ),
             File(
@@ -458,7 +487,8 @@ def generate_encounter_for(name: str, tier: str) -> FolderCollection:
             lastmod,
             patch,
             changelog,
-            # TODO: tags???
+            seo_description,
+            seo_tag_relation,
         ],
     )
 

--- a/scripts/generate_config.py
+++ b/scripts/generate_config.py
@@ -207,6 +207,7 @@ author_profile = FolderCollection(
 
 seo_tag_collection = FolderCollection(
     name="seo-tags",
+    label="SEO tags",
     folder="data/seo/tags",
     format="json",
     identifier_field="tag",
@@ -503,6 +504,7 @@ netlify = NetlifyConfig(
     collections=[
         role_metadata,
         author_profile,
+        seo_tag_collection,
         FileCollection(
             name="role-landing",
             label="Role Landing Pages",

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,4 @@
+netlify-config-generator @ git+https://github.com/nonowazu/netlify-config-generator@f362afea9357e6870d0fb1953d4b3999b66ea202
+pydantic==1.10.2
+PyYAML==6.0
+typing_extensions==4.3.0


### PR DESCRIPTION
Add some python and a small library I created to dynamically generate the netlify configuration. Successful dogfooding of this in dev should result in me pushing that library to pypi for future consumption (removing the git dependency in requirements.txt).

Current instructions for use (from the scripts directory):

* (optional) Make a virtualenv with `python -mvenv env` (I think this works with python 3.10 or higher, but when I'm done it should be 3.7 or higher)
* `pip install -r requirements.txt`
* `python generate_config.py > ../exampleSite/static/admin/dev.yml`
* test with usual `yarn start:dev` commands

I wouldn't bother too hard with reviewing dev.yml, but I figured it would be nice to include it as part of this PR for "rapid start" (I don't see this changing too often)