### PR TITLE
Add missing font-weights for Roboto

### DIFF
--- a/layouts/editor/baseof.html
+++ b/layouts/editor/baseof.html
@@ -17,7 +17,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Kumbh+Sans:wght@100;700&family=Roboto:ital,wght@0,100;0,400;0,700;1,100;1,400;1,700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Kumbh+Sans:wght@100;700&family=Roboto:ital,wght@0,100;0,300;0,400;0,500;0,700;1,100;1,300;1,400;1,500;1,700&display=swap"
       rel="stylesheet"
     />
     <!-- netlify-cms config -->

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -28,7 +28,7 @@
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link
-  href="https://fonts.googleapis.com/css2?family=Kumbh+Sans:wght@100;700&family=Roboto:ital,wght@0,100;0,400;0,700;1,100;1,400;1,700&display=swap"
+  href="https://fonts.googleapis.com/css2?family=Kumbh+Sans:wght@100;700&family=Roboto:ital,wght@0,100;0,300;0,400;0,500;0,700;1,100;1,300;1,400;1,500;1,700&display=swap"
   rel="stylesheet"
 />
 {{ $styles := resources.Get "css/main.css" | postCSS }}


### PR DESCRIPTION
The font weight 300 was missing, which made "font-light" fallback to the font weight 100. This provides bad readability at a font size of 14px.
Roboto does not provide the font weight 600 for "font-semibold", but for consistency I added the font weight 500 as well.
I also updated the admin index.html so the fonts used in the admin UI match those in the theme. It might make sense to update it in the main repository as well.

This has been especially visible on the copyright text on the footer.

Before:
![image](https://github.com/The-Balance-FFXIV/glam/assets/18734648/ee883e16-68cf-4f54-881c-e33013b66ad0)

After:
![image](https://github.com/The-Balance-FFXIV/glam/assets/18734648/5902457a-5c83-42eb-aed8-4a0794dcfec0)