### PR TITLE
Add discord icon to discord username

### DIFF
--- a/layouts/partials/components/author_box.html
+++ b/layouts/partials/components/author_box.html
@@ -6,6 +6,9 @@
   </div>
   <div class="text-center text-gray-light">{{ .name }}</div>
   {{ with .socials.discord_id }}
-    <div class="text-center text-gray-light">{{ . }}</div>
+    <div class="text-center text-gray-light flex flex-nowrap items-center justify-center">
+        <img class="w-4 mr-4" src="/theme-assets/icons/discord_logo_white.svg" />
+        {{ . }}
+    </div>
   {{ end }}
 </div>


### PR DESCRIPTION
To address The-Balance-FFXIV/balance-static#1001, adds a discord icon to discern what the username is for. 

I did notice that the original issue stated adding lighter text or the icon, and I can see lighter text was added. But, considering discord usernames no longer have their notorious `#123` suffix, I think when those start to be updated the distinction of it being a discord username will be valuable. 