### PR TITLE
Add options that are missing from current production generation

### DIFF
--- a/tools/econfgen/econfgen.yml.example
+++ b/tools/econfgen/econfgen.yml.example
@@ -38,6 +38,9 @@ default:
 prod:
   # any items here will override everything in the default
   local_backend: false
+  publish_mode: editorial_workflow
+  site_url: https://glam.thebalanceffxiv.com/
+  show_preview_links: true
   backend: 
     name: github
     repo: foo/bar

--- a/tools/econfgen/src/econfgen/__init__.py
+++ b/tools/econfgen/src/econfgen/__init__.py
@@ -12,6 +12,7 @@ from econfgen.collections import (
     generate_job_guide,
     generate_fight_tips,
 )
+from econfgen.models import PUBLISH_MODES
 
 
 JOBS: Final[Dict[str, List[Tuple[str, str]]]] = {
@@ -47,12 +48,21 @@ JOBS: Final[Dict[str, List[Tuple[str, str]]]] = {
 }
 
 
-def generate_config(backend: Backend = Backend(name='git-gateway'), local_backend: Optional[bool] = True, jobs=JOBS):
+def generate_config(
+    backend: Backend = Backend(name='git-gateway'),
+    local_backend: Optional[bool] = True,
+    publish_mode: Optional[PUBLISH_MODES] = None,
+    site_url: Optional[str] = None,
+    show_preview_links: Optional[bool] = None,
+    jobs=JOBS,
+):
     # TODO: generate some more collections by config
-
     return NetlifyConfig(
         backend=backend,
         local_backend=local_backend,
+        publish_mode=publish_mode,
+        site_url=site_url,
+        show_preview_links=show_preview_links,
         media_folder='static/img',
         public_folder='/img',
         collections=[

--- a/tools/econfgen/src/econfgen/__main__.py
+++ b/tools/econfgen/src/econfgen/__main__.py
@@ -43,8 +43,14 @@ def main() -> int:
     else:
         final_config = config.default
 
+    # TODO: this is ugly, just pass the pydantic model instead
     config = generate_config(
-        backend=final_config.backend, local_backend=final_config.local_backend, jobs=final_config.jobs
+        backend=final_config.backend,
+        local_backend=final_config.local_backend,
+        publish_mode=final_config.publish_mode,
+        site_url=final_config.site_url,
+        show_preview_links=final_config.show_preview_links,
+        jobs=final_config.jobs,
     )
     print(dump(config.dict()))
     return 0

--- a/tools/econfgen/src/econfgen/models.py
+++ b/tools/econfgen/src/econfgen/models.py
@@ -3,11 +3,12 @@ from typing import Dict, List, Tuple, Optional, Literal
 from pydantic import BaseSettings, BaseModel
 from netlifyconfig.netlify import Backend
 
+PUBLISH_MODES = Literal['simple', 'editorial_workflow']
 
 class Environment(BaseModel):
     backend: Backend
     local_backend: Optional[bool] = None
-    publish_mode: Optional[Literal['simple', 'editorial_workflow']] = None
+    publish_mode: Optional[PUBLISH_MODES] = None
     site_url: Optional[str] = None
     show_preview_links: Optional[bool] = None
     jobs: Dict[str, List[Tuple[str, str]]]
@@ -16,7 +17,7 @@ class Environment(BaseModel):
 class OverrideableEnvironment(BaseModel):
     backend: Optional[Backend]
     local_backend: Optional[bool]
-    publish_mode: Optional[Literal['simple', 'editorial_workflow']] = None
+    publish_mode: Optional[PUBLISH_MODES] = None
     site_url: Optional[str] = None
     show_preview_links: Optional[bool] = None
     jobs: Optional[Dict[str, List[Tuple[str, str]]]]

--- a/tools/econfgen/src/econfgen/models.py
+++ b/tools/econfgen/src/econfgen/models.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Tuple, Optional
+from typing import Dict, List, Tuple, Optional, Literal
 
 from pydantic import BaseSettings, BaseModel
 from netlifyconfig.netlify import Backend
@@ -7,6 +7,9 @@ from netlifyconfig.netlify import Backend
 class Environment(BaseModel):
     backend: Backend
     local_backend: Optional[bool] = None
+    publish_mode: Optional[Literal['simple', 'editorial_workflow']] = None
+    site_url: Optional[str] = None
+    show_preview_links: Optional[bool] = None
     jobs: Dict[str, List[Tuple[str, str]]]
 
 

--- a/tools/econfgen/src/econfgen/models.py
+++ b/tools/econfgen/src/econfgen/models.py
@@ -16,6 +16,9 @@ class Environment(BaseModel):
 class OverrideableEnvironment(BaseModel):
     backend: Optional[Backend]
     local_backend: Optional[bool]
+    publish_mode: Optional[Literal['simple', 'editorial_workflow']] = None
+    site_url: Optional[str] = None
+    show_preview_links: Optional[bool] = None
     jobs: Optional[Dict[str, List[Tuple[str, str]]]]
 
 


### PR DESCRIPTION
Using [`deep`](https://github.com/seperman/deepdiff) with the current production yaml in balance-static and the generated yaml in glam results in some discrepancies:

``` 
[3.12|env][king@guren:balance-static (main[✘!?])]$ deep diff --ignore-order static/admin.old/config.yml static/admin/config.yml | head -n 10
{
  "dictionary_item_added": [
    "root['local_backend']"
  ],
  "dictionary_item_removed": [
    "root['publish_mode']",
    "root['site_url']",
    "root['show_preview_links']",
    "root['backend']['site_domain']"
  ],
```

This PR adds almost all those fields in to the generation.

I'm not 100% sure that `site_domain` is [absolutely required](https://decapcms.org/docs/backends-overview/) (someone obviously double-check me here), and if it is it will require an update on my [upstream repo](https://github.com/nonowazu/netlify-config-generator/blob/main/netlifyconfig/netlify.py), but in the interest of speed I'll patch it locally if it becomes an issue.