### PR TITLE
Fix jumping cursor issue on editor in chrome

### DIFF
--- a/layouts/editor/baseof.html
+++ b/layouts/editor/baseof.html
@@ -26,6 +26,12 @@
     <script src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>
     <!-- Darkreader -->
     <script src="https://cdn.jsdelivr.net/npm/darkreader@4.9.27/darkreader.min.js"></script>
+    {{/* https://github.com/decaporg/decap-cms/issues/5092 */}}
+    <style>
+	[data-slate-editor] { 
+	    -webkit-user-modify: read-write !important; 
+	}
+    </style>
   </head>
   <body>
     <!-- Include the script that builds the page and powers Netlify CMS -->


### PR DESCRIPTION
Just like it says on the tin - this was fixed in balance-static previously, but I don't think the fix ever propagated back. Or I was blinded ~~by science~~ and missed it.