### PR TITLE
Add more preview styling for guide entries

### DIFF
--- a/layouts/editor/baseof.html
+++ b/layouts/editor/baseof.html
@@ -60,6 +60,8 @@
       CMS.registerPreviewTemplate("landing", LandingPreviewTemplate);
       CMS.registerPreviewTemplate("leveling-guide", GenericJobGuide);
       CMS.registerPreviewTemplate("basic-guide", GenericJobGuide);
+      CMS.registerPreviewTemplate("intermediate-guide", GenericJobGuide);
+      CMS.registerPreviewTemplate("advanced-guide", GenericJobGuide);
       CMS.registerPreviewTemplate("skills-overview", GenericJobGuide);
       CMS.registerPreviewTemplate("openers", GenericJobGuide);
     </script>


### PR DESCRIPTION
It was ~~thousands~~ two years ago when I added the preview styles and I forgot to add some for the guide types we had (and now have). The faq/bis ones still need to be written, so I'll put in a github issue to track against.