### PR TITLE
Update license to reflect proper copyright

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,8 @@
 The MIT License (MIT)
 
-Copyright (c) 2021 YOUR_NAME_HERE
+Copyright (c) 2021-2024 The Glam Project Developers and Contributors
+See the contributor and developer list at https://github.com/The-Balance-FFXIV/glam/contributors
+
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in


### PR DESCRIPTION
The previous copyright line was incorrect; this fixes it to reflect all contributors.