### PR TITLE
Melee Role Landing Split

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -332,7 +332,7 @@ Content
 }
 
 .tab-jobs {
-  @apply items-center block md:flex md:flex-wrap md:flex-grow w-full lg:w-1/2 md:justify-evenly font-head mt-4 lg:mt-0;
+  @apply items-start block md:flex md:flex-wrap md:flex-grow w-full lg:w-1/2 font-head mt-4 lg:mt-0;
 }
 
 .tabs.desktop {
@@ -355,7 +355,7 @@ Content
 }
 
 .tab-job-container {
-  @apply flex flex-col w-auto py-3 md:w-1/2 xl:w-auto justify-center items-start md:items-center;
+  @apply flex flex-col w-auto py-3 md:w-1/2 xl:w-1/4 justify-center items-start md:items-center;
 }
 
 .tab-job-link {


### PR DESCRIPTION
PR to address #361 : Melee spilling over into a 5-1 split on role landing

Modified `main.css` due to partial layouts only having CSS class applied to them and no Tailwind on the elements directly (`layouts/partials/homepage/role_slider` both `content.html` and `job.html`)
- Adjusted maximum number of icons in row to be 4 so that it is even and overflows nicely
- Changed flex classes to have all items start in the top left rather than the middle since melee starts on the top with the second row
  - This will also help in the future when more jobs come in as it should handle 5th tank, healer, caster dps job in the future
- Mobile and tablet should be unaffected

New wrapping layout for melee DPS:
![Screenshot 2024-08-09 at 8 43 48 AM](https://github.com/user-attachments/assets/4732f2b7-7b0a-4bf7-9f83-1e49775966db)

Display of how other job layout will look:
![Screenshot 2024-08-09 at 8 43 20 AM](https://github.com/user-attachments/assets/00498925-2a52-4935-8ff4-86b6a2198796)

Tablet layout (should be unaffected):
![Screenshot 2024-08-09 at 8 44 30 AM](https://github.com/user-attachments/assets/a5e53993-79e4-4157-9ec0-f9ac1518d414)

Mobile layout (should be unaffected):
![Screenshot 2024-08-09 at 8 44 46 AM](https://github.com/user-attachments/assets/6daee08b-691f-43b0-b7d9-0de8a4a66fd5)

