### PR TITLE
Update deprecated .Site.IsServer to hugo.IsServer

### DIFF
--- a/.github/workflows/pr-creation.yml
+++ b/.github/workflows/pr-creation.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v3
         with:
-          hugo-version: '0.119.0'
+          hugo-version: '0.134.2'
           extended: true
 
       - name: Setup node

--- a/layouts/editor/baseof.html
+++ b/layouts/editor/baseof.html
@@ -1,7 +1,7 @@
 {{ $scratch := newScratch }}
 {{ $scratch.Set "style" (resources.Get "css/main.css" | postCSS) }}
 {{ $scratch.Set "config" (default "config.yml" (index .Params "config")) }}
-{{ if .Site.IsServer }}
+{{ if hugo.IsServer }}
   {{/* development */}}
   {{ $scratch.Set "config" (default "dev.yml" (index .Params "dev_config")) }}
 {{ else }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -32,7 +32,7 @@
   rel="stylesheet"
 />
 {{ $styles := resources.Get "css/main.css" | postCSS }}
-{{ if .Site.IsServer }}
+{{ if hugo.IsServer }}
   <link rel="stylesheet" href="{{ $styles.RelPermalink }}" />
 {{ else }}
   {{ $styles := $styles | minify | fingerprint | resources.PostProcess }}

--- a/theme.toml
+++ b/theme.toml
@@ -8,7 +8,7 @@ description = "A theme for The Balance"
 homepage = "https://github.com/The-Balance-FFXIV/glam/"
 tags = []
 features = []
-min_version = "0.119.0"
+min_version = "0.120.0"
 
 [author]
   name = ""


### PR DESCRIPTION
It seems like `.Site.IsServer` was deprecated in Hugo `0.120`, and as a result you're unable to build with modern versions. Changing to `hugo.IsServer` seems to work great. This was the only change I needed to make to get it to work locally.

Before:
```
violet@damsel-of-distress:~/Repositories/balance-static$ hugo server --disableFastRender
Watching for changes in /home/violet/Repositories/balance-static/{archetypes,content,data,layouts,package.json,postcss.config.js,static,tailwind.config.js,themes}
Watching for config changes in /home/violet/Repositories/balance-static/config.toml
Start building sites …
hugo v0.134.1-2f89169baa87a9db47e288b60705f4e99e21a945+extended linux/amd64 BuildDate=2024-09-05T10:17:50Z VendorInfo=snap:0.134.1

ERROR deprecated: .Site.IsServer was deprecated in Hugo v0.120.0 and will be removed in Hugo 0.135.0. Use hugo.IsServer instead.
Built in 823 ms
Error: error building site: logged 1 error(s)
```

After:
```
violet@damsel-of-distress:~/Repositories/balance-static$ hugo server --disableFastRender
Watching for changes in /home/violet/Repositories/balance-static/{archetypes,content,data,layouts,package.json,postcss.config.js,static,tailwind.config.js,themes}
Watching for config changes in /home/violet/Repositories/balance-static/config.toml
Start building sites …
hugo v0.134.1-2f89169baa87a9db47e288b60705f4e99e21a945+extended linux/amd64 BuildDate=2024-09-05T10:17:50Z VendorInfo=snap:0.134.1


                   |  EN
-------------------+-------
  Pages            |  371
  Paginator pages  |    0
  Non-page files   |    0
  Static files     | 1346
  Processed images |    0
  Aliases          |   15
  Cleaned          |    0

Built in 2014 ms
Environment: "development"
Serving pages from disk
Web Server is available at http://localhost:1313/ (bind address 127.0.0.1)
Press Ctrl+C to stop
```