### PR TITLE
Update generic link to not be fixed height

### DIFF
--- a/layouts/partials/components/embeds/genericlink.html
+++ b/layouts/partials/components/embeds/genericlink.html
@@ -1,3 +1,3 @@
-<div class="h-96">
+<div>
   <a href="{{ . }}">{{ . }}</a>
 </div>


### PR DESCRIPTION
Updates genericlink embeds (for BiS pages, in particular) to not have a fixed height, so that they don't take up extra screen real estate.