### PR TITLE
fix editor preview not showing page styling on certain page previews

### DIFF
--- a/layouts/editor/baseof.html
+++ b/layouts/editor/baseof.html
@@ -64,6 +64,10 @@
       CMS.registerPreviewTemplate("advanced-guide", GenericJobGuide);
       CMS.registerPreviewTemplate("skills-overview", GenericJobGuide);
       CMS.registerPreviewTemplate("openers", GenericJobGuide);
+      CMS.registerPreviewTemplate("bis", GenericJobGuide);
+      CMS.registerPreviewTemplate("stat-priority", GenericJobGuide);
+      CMS.registerPreviewTemplate("faq", GenericJobGuide);
+      CMS.registerPreviewTemplate("job-changes", GenericJobGuide);
     </script>
   </body>
 </html>


### PR DESCRIPTION
fixes certain pages in the editor preview not using real website styling for BIS/stat-priority/job-changes/FAQ pages

the root problem of why it didn't style those pages seems to just be that it was never added in the first place where it was added for the other pages