### PR TITLE
fixes bis preview in editor, tailwind config edit for widescreen

### DIFF
--- a/layouts/editor/baseof.html
+++ b/layouts/editor/baseof.html
@@ -64,6 +64,7 @@
       CMS.registerPreviewTemplate("advanced-guide", GenericJobGuide);
       CMS.registerPreviewTemplate("skills-overview", GenericJobGuide);
       CMS.registerPreviewTemplate("openers", GenericJobGuide);
+      CMS.registerPreviewTemplate("bis", bisSetTemplate);
     </script>
   </body>
 </html>

--- a/layouts/jobs/bis.html
+++ b/layouts/jobs/bis.html
@@ -16,26 +16,26 @@
   {{ partial "job/single_header.html" $header }}
 
   <div class="responsive-container">
+    <div class="job-guides-container">
+      <div class="markdown max-w-none">
+        {{ range $index, $bis := .Params.bis }}
+          <h2 id="{{ $index }}">{{ $bis.name }}</h2>
+          {{ $partialPath := printf "components/embeds/%s.html" $bis.type }}
+          {{ if templates.Exists (printf "partials/%s" $partialPath) }}
+            {{ partial $partialPath $bis.link }}
+          {{ else }}
+            {{/* Fallback to generic link if no template matches.
+                 This shouldn't generally happen.
+            */}}
+            {{ partial "components/embeds/genericlink.html" $bis.link }}
+          {{ end }}
+          {{ $bis.description | markdownify }}
+        {{ end }}
+      </div>
+    </div>
     <div class="md:grid grid-cols-12 items-start gap-8 w-full">
       <div class="table-of-contents-container max-h-screen overflow-y-auto">
         {{ partial "components/toc.html" . }}
-      </div>
-      <div class="job-guides-container">
-        <div class="markdown max-w-none">
-          {{ range $index, $bis := .Params.bis }}
-            <h2 id="{{ $index }}">{{ $bis.name }}</h2>
-            {{ $partialPath := printf "components/embeds/%s.html" $bis.type }}
-            {{ if templates.Exists (printf "partials/%s" $partialPath) }}
-              {{ partial $partialPath $bis.link }}
-            {{ else }}
-              {{/* Fallback to generic link if no template matches.
-                   This shouldn't generally happen.
-              */}}
-              {{ partial "components/embeds/genericlink.html" $bis.link }}
-            {{ end }}
-            {{ $bis.description | markdownify }}
-          {{ end }}
-        </div>
       </div>
     </div>
   </div>

--- a/static/theme-assets/editor/job-preview.js
+++ b/static/theme-assets/editor/job-preview.js
@@ -15,6 +15,36 @@ const renderGuideContainer = function (body, ...children) {
   );
 };
 
+const renderBisList = function (bis) {
+  const bisList = bis;
+
+  return h(
+    "div", {}, bisList.map(function (bis, indexer) {
+        const name = h("h2", {}, bis.name);
+        const type = bis.type;
+        const link = bis.link;
+        const description = h("p", {}, bis.description);
+        const bisFrame =
+          type != "plaintext"
+            ? h("div", { class: "h-96" }, h("iframe", {
+                src: 
+                  type === "etro" ? `https://etro.gg/embed/gearset/${link}` : 
+                  link,
+                class: "w-full h-full",
+              }))
+              : link;
+
+        return h(
+          "div",
+          { key: indexer, id: `bis-preview-${indexer}`, },
+          name,
+          bisFrame,
+          description,
+        );
+      })
+    )
+};
+
 const renderAuthorList = function (authors) {
   let authorList = authors ?? [];
   return h(
@@ -39,6 +69,17 @@ let GenericJobGuide = createClass({
       this.props.widgetFor("body"),
       h("hr", {}),
       renderAuthorList(authors)
+    );
+  },
+});
+
+let bisSetTemplate = createClass({
+  render: function () {
+    const bis = this.props.entry.getIn(["data", "bis"]);
+    const bisList = typeof bis.toJS === "function" ? bis.toJS() : bis;
+
+    return renderGuideContainer(
+      renderBisList(bisList)
     );
   },
 });

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -28,6 +28,17 @@ module.exports = {
       'sans': ['Roboto', 'sans-serif'],
       'head': ['Kumbh Sans', 'sans-serif']
     },
+    container: {
+        screens: {
+            'sm': '640px',
+            'md': '768px',
+            'lg': '1024px',
+            'xl': '1280px',
+            '2xl': '1536px',
+            '3xl': '1920px',
+            '4xl': '2560px',
+        }
+    },
     extend: {
       dropShadow: {
         'lg': '2px 2px 3px #000000',


### PR DESCRIPTION
1. enables proper bis preview within the editor panel (the xivgear set is blank because there is no set saved on xivgear's side, but the set loading is proper/the embedding works fine)
2. enables two new media breakpoints that are wider than the default tailwind breakpoints for responsive-container (the original breakpoints are preserved)
3. enables full content width for the live bis page since the table of contents does not actually exist and is pinching the bis content

basically just a combination of the last two PRs and this time its a real fix for the bis previewer

note: needs to have something done to allow straight etro links to get pasted in since i don't think you can make hugo's replaceRE do that in a .js file for the CMS renderer, for now etro links require the embed code for the previewer to work

<img width="3322" height="1287" alt="image" src="https://github.com/user-attachments/assets/0efe3583-a5f0-4f02-9e97-338d9b0eaf73" />
<img width="2318" height="1214" alt="image" src="https://github.com/user-attachments/assets/64e9b847-9090-4ad9-bd9b-2cf95aa36ea3" />

