### PR TITLE
Better default embed sizes

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -688,3 +688,19 @@ ol {
   flex-wrap: wrap;
   gap: 5px;
 }
+
+.xivgear-embed-size {
+  height: 44rem;
+}
+
+.xivgear-iframe-height {
+  height: 44rem;
+}
+
+.etro-embed-size {
+  height: 40rem;
+}
+
+.etro-iframe-height {
+  height: 40rem;
+}

--- a/layouts/jobs/bis.html
+++ b/layouts/jobs/bis.html
@@ -29,7 +29,10 @@
             */}}
             {{ partial "components/embeds/genericlink.html" $bis.link }}
           {{ end }}
+          {{ if $bis.description }}
+          </br>
           {{ $bis.description | markdownify }}
+          {{ end }}
         {{ end }}
       </div>
     </div>

--- a/layouts/partials/components/embeds/etro.html
+++ b/layouts/partials/components/embeds/etro.html
@@ -1,5 +1,5 @@
-<div class="h-96">
-  <iframe class="w-full h-full"
+<div class="etro-embed-size">
+  <iframe class="w-full etro-iframe-height"
     title="Etro Gearset" 
     src="https://etro.gg/embed/gearset/{{ replaceRE `^https?://etro\.gg/gearset/` `` . }}">
   </iframe>

--- a/layouts/partials/components/embeds/xivgear.html
+++ b/layouts/partials/components/embeds/xivgear.html
@@ -1,5 +1,5 @@
-<div class="h-96">
-  <iframe class="w-full h-full"
+<div class="xivgear-embed-size">
+  <iframe class="w-full xivgear-iframe-height"
     title="Xivgear"
     src="{{ . }}">
   </iframe>


### PR DESCRIPTION
This commit does two things:

## 1: Add a line break between embed and description
### Before
<img width="751" height="141" alt="image" src="https://github.com/user-attachments/assets/8b234803-9900-49f5-ad56-18a0bc9c0472" />

### After
<img width="791" height="226" alt="image" src="https://github.com/user-attachments/assets/e7816e59-3e53-4526-ab46-5090c258736d" />

## 2: Changes default embed size to show more of the gearset
### Etro
<img width="1737" height="791" alt="image" src="https://github.com/user-attachments/assets/44c5f6a2-db4e-45cc-9529-15ad19620251" />
### Xivgear (uses new embed experience preview)
<img width="1721" height="880" alt="image" src="https://github.com/user-attachments/assets/e43d9eba-5cb9-473e-b702-82ea23e9444d" />

### Xivgear (live)
<img width="1739" height="842" alt="image" src="https://github.com/user-attachments/assets/87c154e2-9d5c-4e42-a35d-164ca4dbcfa8" />
