### PR TITLE
fix for etro case bug

### DIFF
--- a/static/theme-assets/editor/job-preview.js
+++ b/static/theme-assets/editor/job-preview.js
@@ -46,7 +46,7 @@ const renderBisList = function (bis) {
             var bisFrame = link;
             break;
           default:
-            var bisFrame = h("div", { class: "h-96" }, h("iframe", {
+            var bisFrame = h("div", { class: "etro-iframe-height" }, h("iframe", {
               src: link,
               class: "w-full h-full"
             }));


### PR DESCRIPTION
a previous error in the case handling of the full etro link could result in a null value on the call to match the link to identify etro links, which errored out the editor preview page. for some reason, it would display correctly on the example site's scholar bis .md which resulted in the bug being missed, but this was tested using prod's .md with etro links of different varieties and seems to appropriately work, so this should fix the issue.

thanks sila for the suggestion on this case handling method

<img width="927" height="607" alt="image" src="https://github.com/user-attachments/assets/42d5f13b-95d2-4681-9d80-91b1ed134e4b" />
<img width="2450" height="1309" alt="image" src="https://github.com/user-attachments/assets/6571f609-344c-4867-b151-ca839f4ff250" />
<img width="2498" height="1240" alt="image" src="https://github.com/user-attachments/assets/24f220c9-1d19-4d63-9132-8d4860bcfd8c" />

