### PR TITLE
add validation for xivgear embed, add case for etro iframe generation, make xivgear field consistent with prod

### DIFF
--- a/exampleSite/static/admin/dev.yml
+++ b/exampleSite/static/admin/dev.yml
@@ -1459,7 +1459,7 @@ collections:
         - sleepyshiba
         - genericiframe
         - genericlink
-        - xivgearset
+        - xivgear
         required: false
         widget: select
       - label: Link
@@ -2228,7 +2228,7 @@ collections:
         - sleepyshiba
         - genericiframe
         - genericlink
-        - xivgearset
+        - xivgear
         required: false
         widget: select
       - label: Link
@@ -2997,7 +2997,7 @@ collections:
         - sleepyshiba
         - genericiframe
         - genericlink
-        - xivgearset
+        - xivgear
         required: false
         widget: select
       - label: Link
@@ -3766,7 +3766,7 @@ collections:
         - sleepyshiba
         - genericiframe
         - genericlink
-        - xivgearset
+        - xivgear
         required: false
         widget: select
       - label: Link
@@ -4535,7 +4535,7 @@ collections:
         - sleepyshiba
         - genericiframe
         - genericlink
-        - xivgearset
+        - xivgear
         required: false
         widget: select
       - label: Link
@@ -5304,7 +5304,7 @@ collections:
         - sleepyshiba
         - genericiframe
         - genericlink
-        - xivgearset
+        - xivgear
         required: false
         widget: select
       - label: Link
@@ -6073,7 +6073,7 @@ collections:
         - sleepyshiba
         - genericiframe
         - genericlink
-        - xivgearset
+        - xivgear
         required: false
         widget: select
       - label: Link
@@ -6842,7 +6842,7 @@ collections:
         - sleepyshiba
         - genericiframe
         - genericlink
-        - xivgearset
+        - xivgear
         required: false
         widget: select
       - label: Link
@@ -7611,7 +7611,7 @@ collections:
         - sleepyshiba
         - genericiframe
         - genericlink
-        - xivgearset
+        - xivgear
         required: false
         widget: select
       - label: Link
@@ -8380,7 +8380,7 @@ collections:
         - sleepyshiba
         - genericiframe
         - genericlink
-        - xivgearset
+        - xivgear
         required: false
         widget: select
       - label: Link
@@ -9149,7 +9149,7 @@ collections:
         - sleepyshiba
         - genericiframe
         - genericlink
-        - xivgearset
+        - xivgear
         required: false
         widget: select
       - label: Link
@@ -9918,7 +9918,7 @@ collections:
         - sleepyshiba
         - genericiframe
         - genericlink
-        - xivgearset
+        - xivgear
         required: false
         widget: select
       - label: Link
@@ -10687,7 +10687,7 @@ collections:
         - sleepyshiba
         - genericiframe
         - genericlink
-        - xivgearset
+        - xivgear
         required: false
         widget: select
       - label: Link
@@ -11456,7 +11456,7 @@ collections:
         - sleepyshiba
         - genericiframe
         - genericlink
-        - xivgearset
+        - xivgear
         required: false
         widget: select
       - label: Link
@@ -12225,7 +12225,7 @@ collections:
         - sleepyshiba
         - genericiframe
         - genericlink
-        - xivgearset
+        - xivgear
         required: false
         widget: select
       - label: Link
@@ -12994,7 +12994,7 @@ collections:
         - sleepyshiba
         - genericiframe
         - genericlink
-        - xivgearset
+        - xivgear
         required: false
         widget: select
       - label: Link
@@ -13763,7 +13763,7 @@ collections:
         - sleepyshiba
         - genericiframe
         - genericlink
-        - xivgearset
+        - xivgear
         required: false
         widget: select
       - label: Link
@@ -14532,7 +14532,7 @@ collections:
         - sleepyshiba
         - genericiframe
         - genericlink
-        - xivgearset
+        - xivgear
         required: false
         widget: select
       - label: Link
@@ -15301,7 +15301,7 @@ collections:
         - sleepyshiba
         - genericiframe
         - genericlink
-        - xivgearset
+        - xivgear
         required: false
         widget: select
       - label: Link
@@ -16070,7 +16070,7 @@ collections:
         - sleepyshiba
         - genericiframe
         - genericlink
-        - xivgearset
+        - xivgear
         required: false
         widget: select
       - label: Link
@@ -16839,7 +16839,7 @@ collections:
         - sleepyshiba
         - genericiframe
         - genericlink
-        - xivgearset
+        - xivgear
         required: false
         widget: select
       - label: Link

--- a/static/theme-assets/editor/job-preview.js
+++ b/static/theme-assets/editor/job-preview.js
@@ -31,7 +31,8 @@ const renderBisList = function (bis) {
         let bisFrame;
         switch(type) {
           case "plain-text":
-            // Plain text does not need an iframe, and can just be included as the given text (in the link field)
+          case "genericlink":
+            // Plain text and links do not need an iframe, and can just be included as the given text (in the link field)
             bisFrame = link;
             break;
           case "xivgear":

--- a/static/theme-assets/editor/job-preview.js
+++ b/static/theme-assets/editor/job-preview.js
@@ -46,7 +46,7 @@ const renderBisList = function (bis) {
             var bisFrame = link;
             break;
           default:
-            var bisFrame = h("div", { class: "h-96" }, h("iframe", {
+            var bisFrame = h("div", { class: "etro-iframe-height" }, h("iframe", {
               src: link,
               class: "w-full h-full"
             }));

--- a/static/theme-assets/editor/job-preview.js
+++ b/static/theme-assets/editor/job-preview.js
@@ -61,7 +61,7 @@ const renderBisList = function (bis) {
             break;
           default:
             if (String(link).includes("xivgear" || "etro")) {
-              bisFrame = h("p", {}, "The type selected does not match the link provided. Please check the type selection.");
+              bisFrame = h("div", {}, h("p", {}, "You are currently using either an Etro or XIVGear link with an improper link type selected (e.g. genericiframe)."), h("p", {}, "Please double-check that the type selection matches what type of link you are using."));
             } else {
               bisFrame = h("div", { class: "h-96" }, h("iframe", {
                 src: link,

--- a/static/theme-assets/editor/job-preview.js
+++ b/static/theme-assets/editor/job-preview.js
@@ -16,80 +16,62 @@ const renderGuideContainer = function (body, ...children) {
 };
 
 const renderBisList = function (bis) {
-  const bisList = bis;
+  const bisEntries = bis;
 
   return h(
-    "div", {}, bisList.map(function (bis, indexer) {
-        const name = h("h2", {}, bis.name);
-        const type = bis.type;
-        let description = h("p", {}, bis.description);
-        let link = bis.link;
-        
-        // Normalize links where applicable
-
-        // Handle special cases of the BiS display
-        let bisFrame;
-        let errorDetection = false; // Hides description if an error in link input is detected to improve error readability
-        switch(type) {
-          case "plain-text":
-          case "genericlink":
-            // Plain text and links does not need an iframe, and can just be included as the given text (in the link field)
-            bisFrame = link;
-            break;
-          case "xivgear":
-            // XIVGear embed links should be checked for the embed format
-            if (!String(link).includes("embed")) {
-              bisFrame = h("p", {}, "This XIVGear link does not appear to be an embed link. Please check the link.");
-              errorDetection = true;
-            } else {
-              bisFrame = h("div", { class: "xivgear-iframe-height" }, h("iframe", {
-                src: link,
-                class: "w-full h-full"
-              }));
-            }
-            break;
-          case "etro":
-            // Etro links should be have their gearset ID extracted to always convert to the embedded format
-            const etroLink = link.match(/\/gearset\/([A-Za-z0-9-]+)(?:[?#]|$)/i);
-            if(etroLink) {
-              link = etroLink[1]
-            }
-            // Make etro links always become the embedded form
-            link = `https://etro.gg/embed/gearset/${link}`
-            bisFrame = h("div", { class: "etro-iframe-height" }, h("iframe", {
-              src: link,
-              class: "w-full h-full"
-            }));
-            break;
-          default:
-            if (String(link).includes("xivgear" || "etro")) {
-              bisFrame = h("div", {}, 
-                h("p", {}, "You currently have either an Etro link or a XIVGear link in the link field with an improper link type selected for that type of link (e.g. genericiframe)."), 
+    "div", {}, bisEntries.map(function (bis, indexer) {
+      // Sort bis frontmatter fields into variables and prep for rendering
+      const name = h("h2", {}, bis.name);
+      const type = bis.type;
+      let description = h("p", {}, bis.description);
+      let link = bis.link;
+      
+      // Create embed element and check for input errors based on type
+      let bisFrame;
+      let errorDetection = false; // Hides description if link or link type validation fails
+      switch(type) {
+        case "plain-text":
+        case "genericlink":
+          bisFrame = link; // both of these types do not require an iframe
+          break;
+        case "xivgear": // check for embed link before creating iframe
+          const isEmbed = String(link).includes("embed");
+          errorDetection = !isEmbed;
+          bisFrame = isEmbed
+            ? h("div", { class: "xivgear-iframe-height" }, h("iframe", { src: link, class: "w-full h-full" }))
+            : h("p", {}, "This XIVGear link does not appear to be an embed link. Please check the link.");
+          break;
+        case "etro": // extract ID from link to create embed link
+          const etroLink = link.match(/\/gearset\/([A-Za-z0-9-]+)(?:[?#]|$)/i);
+          link = etroLink ? `https://etro.gg/embed/gearset/${etroLink[1]}` : link;
+          bisFrame = h("div", { class: "etro-iframe-height" }, h("iframe", {
+            src: link,
+            class: "w-full h-full"
+          }));
+          break;
+        default: {
+          const checkTypeError = String(link).includes("xivgear") || String(link).includes("etro");
+          errorDetection = checkTypeError;
+          bisFrame = !checkTypeError
+            ? h("div", { class: "h-96" }, h("iframe", { src: link, class: "w-full h-full" }))
+            : h(
+                "div",
+                {},
+                h("p", {}, "You currently have either an Etro link or a XIVGear link in the link field with an improper link type selected for that type of link (e.g. genericiframe)."),
                 h("p", {}, "Please double-check that the type selection matches what type of link you are using, or consider the use of the genericlink / plain-text type if you do not want an embed.")
-              );
-              errorDetection = true;
-            } else {
-              bisFrame = h("div", { class: "h-96" }, h("iframe", {
-                src: link,
-                class: "w-full h-full"
-              }));
-            }
-            break;
+              )
+          break;
         }
-
-        if (errorDetection) {
-          description = null;
-        }
-
-        return h(
-          "div",
-          { key: indexer, id: `bis-preview-${indexer}`, },
-          name,
-          bisFrame,
-          description,
-        );
-      })
-    )
+      }
+      return h(
+        "div",
+        { key: indexer, id: `bis-preview-${indexer}`, },
+        name,
+        bisFrame,
+        description = errorDetection ? null : description,
+      );
+    })
+  )
 };
 
 const renderAuthorList = function (authors) {
@@ -122,11 +104,11 @@ let GenericJobGuide = createClass({
 
 let bisSetTemplate = createClass({
   render: function () {
-    const bis = this.props.entry.getIn(["data", "bis"]);
-    const bisList = typeof bis.toJS === "function" ? bis.toJS() : bis;
+    const rawBis = this.props.entry.getIn(["data", "bis"]);
+    const bis = typeof rawBis.toJS === "function" ? rawBis.toJS() : rawBis;
 
     return renderGuideContainer(
-      renderBisList(bisList)
+      renderBisList(bis)
     );
   },
 });

--- a/static/theme-assets/editor/job-preview.js
+++ b/static/theme-assets/editor/job-preview.js
@@ -22,13 +22,14 @@ const renderBisList = function (bis) {
     "div", {}, bisList.map(function (bis, indexer) {
         const name = h("h2", {}, bis.name);
         const type = bis.type;
-        const description = h("p", {}, bis.description);
+        let description = h("p", {}, bis.description);
         let link = bis.link;
         
         // Normalize links where applicable
 
         // Handle special cases of the BiS display
         let bisFrame;
+        let errorDetection = false; // Hides description if an error in link input is detected to improve error readability
         switch(type) {
           case "plain-text":
           case "genericlink":
@@ -39,6 +40,7 @@ const renderBisList = function (bis) {
             // XIVGear embed links should be checked for the embed format
             if (!String(link).includes("embed")) {
               bisFrame = h("p", {}, "This XIVGear link does not appear to be an embed link. Please check the link.");
+              errorDetection = true;
             } else {
               bisFrame = h("div", { class: "xivgear-iframe-height" }, h("iframe", {
                 src: link,
@@ -61,7 +63,11 @@ const renderBisList = function (bis) {
             break;
           default:
             if (String(link).includes("xivgear" || "etro")) {
-              bisFrame = h("div", {}, h("p", {}, "You are currently using either an Etro or XIVGear link with an improper link type selected (e.g. genericiframe)."), h("p", {}, "Please double-check that the type selection matches what type of link you are using."));
+              bisFrame = h("div", {}, 
+                h("p", {}, "You currently have either an Etro link or a XIVGear link in the link field with an improper link type selected for that type of link (e.g. genericiframe)."), 
+                h("p", {}, "Please double-check that the type selection matches what type of link you are using, or consider the use of the genericlink / plain-text type if you do not want an embed.")
+              );
+              errorDetection = true;
             } else {
               bisFrame = h("div", { class: "h-96" }, h("iframe", {
                 src: link,
@@ -69,6 +75,10 @@ const renderBisList = function (bis) {
               }));
             }
             break;
+        }
+
+        if (errorDetection) {
+          description = null;
         }
 
         return h(

--- a/static/theme-assets/editor/job-preview.js
+++ b/static/theme-assets/editor/job-preview.js
@@ -32,7 +32,7 @@ const renderBisList = function (bis) {
         switch(type) {
           case "plain-text":
           case "genericlink":
-            // Plain text and links do not need an iframe, and can just be included as the given text (in the link field)
+            // Plain text and links does not need an iframe, and can just be included as the given text (in the link field)
             bisFrame = link;
             break;
           case "xivgear":
@@ -60,10 +60,14 @@ const renderBisList = function (bis) {
             }));
             break;
           default:
-            bisFrame = h("div", { class: "h-96" }, h("iframe", {
-              src: link,
-              class: "w-full h-full"
-            }));
+            if (String(link).includes("xivgear" || "etro")) {
+              bisFrame = h("p", {}, "The type selected does not match the link provided. Please check the type selection.");
+            } else {
+              bisFrame = h("div", { class: "h-96" }, h("iframe", {
+                src: link,
+                class: "w-full h-full"
+              }));
+            }
             break;
         }
 

--- a/static/theme-assets/editor/job-preview.js
+++ b/static/theme-assets/editor/job-preview.js
@@ -26,27 +26,40 @@ const renderBisList = function (bis) {
         let link = bis.link;
         
         // Normalize links where applicable
+
+        // Handle special cases of the BiS display
+        let bisFrame;
         switch(type) {
+          case "plain-text":
+            // Plain text does not need an iframe, and can just be included as the given text (in the link field)
+            bisFrame = link;
+            break;
+          case "xivgear":
+            // XIVGear embed links should be checked for the embed format
+            if (!String(link).includes("embed")) {
+              bisFrame = h("p", {}, "This XIVGear link does not appear to be an embed link. Please check the link.");
+            } else {
+              bisFrame = h("div", { class: "xivgear-iframe-height" }, h("iframe", {
+                src: link,
+                class: "w-full h-full"
+              }));
+            }
+            break;
           case "etro":
+            // Etro links should be have their gearset ID extracted to always convert to the embedded format
             const etroLink = link.match(/\/gearset\/([A-Za-z0-9-]+)(?:[?#]|$)/i);
             if(etroLink) {
               link = etroLink[1]
             }
             // Make etro links always become the embedded form
             link = `https://etro.gg/embed/gearset/${link}`
+            bisFrame = h("div", { class: "etro-iframe-height" }, h("iframe", {
+              src: link,
+              class: "w-full h-full"
+            }));
             break;
           default:
-            break;
-        }
-
-        // Handle special cases of the BiS display
-        switch(type) {
-          case "plain-text":
-            // Plain text does not need an iframe, and can just be included as the given text (in the link field)
-            var bisFrame = link;
-            break;
-          default:
-            var bisFrame = h("div", { class: "etro-iframe-height" }, h("iframe", {
+            bisFrame = h("div", { class: "h-96" }, h("iframe", {
               src: link,
               class: "w-full h-full"
             }));


### PR DESCRIPTION
1.  forces the user to use an embed link when the type is set to xivgear to make sure the correct link is being input
<img width="1060" height="267" alt="image" src="https://github.com/user-attachments/assets/37e8cd57-944e-46b7-bde4-c17d89937cec" />

2. merges the etro case into the primary switch call to generate its own custom iframe using the same class the site uses in prod
<img width="955" height="312" alt="image" src="https://github.com/user-attachments/assets/3a28d02c-5df4-4bde-873a-d466b20779b3" />

3. changes every field calling "xivgearset" in dev.yml to "xivgear" to match the prod config.yml file so that we don't have to continue doing checks using an outdated field name and then correct them before shipping to live

4. changes the default case to use the h-96 class to be consistent with prod's embed height for things like gsheets or generic iframes, and adds a validation check to the default case to make sure the user isn't placing an xivgear or etro link in a type that is not xivgear/etro and also isn't plaintext/genericlink
<img width="546" height="147" alt="image" src="https://github.com/user-attachments/assets/dfe0a894-1a76-4e75-9164-23ca93cdf2aa" />

<img width="2467" height="1203" alt="image" src="https://github.com/user-attachments/assets/57b02e65-cf30-49ea-b837-778dd42ab8d0" />
<img width="2340" height="1168" alt="image" src="https://github.com/user-attachments/assets/ade2d437-3773-4c7b-91ba-4ed408e08a3c" />



