### PR TITLE
significantly improve generic rendering function

### DIFF
--- a/layouts/editor/baseof.html
+++ b/layouts/editor/baseof.html
@@ -66,9 +66,10 @@
       CMS.registerPreviewTemplate("advanced-guide", GenericJobGuide);
       CMS.registerPreviewTemplate("skills-overview", GenericJobGuide);
       CMS.registerPreviewTemplate("openers", GenericJobGuide);
-      CMS.registerPreviewTemplate("bis", bisSetTemplate);
+      CMS.registerPreviewTemplate("bis", bisTemplate);
       CMS.registerPreviewTemplate("faq", faqTemplate);
       CMS.registerPreviewTemplate("stat-priority", statPriorityTemplate);
+      CMS.registerPreviewTemplate("job-changes", changesTemplate);
     </script>
   </body>
 </html>


### PR DESCRIPTION
i modified the old FAQ rendering function that would format specifically based on subfield names "e.g. qna -> question qna -> answer" to take *any* input, so that it can be used elsewhere in theoretically any file, which should make building new renderers for pages in the future extremely simple as long as it is just text that needs to render/be styled and doesn't require additional special rendering

<img width="489" height="202" alt="image" src="https://github.com/user-attachments/assets/2ba998ce-565d-436e-bd03-fe69cc90dfaa" />
<img width="871" height="471" alt="image" src="https://github.com/user-attachments/assets/2d0d45ff-9a08-46c4-9254-b5fad5b66a4f" />
<img width="625" height="211" alt="image" src="https://github.com/user-attachments/assets/22e6f9e4-f10a-4723-90d1-d73158d87a30" />
<img width="965" height="796" alt="image" src="https://github.com/user-attachments/assets/09684841-cd3d-40fb-80bd-8d2e6551f52f" />
<img width="587" height="200" alt="image" src="https://github.com/user-attachments/assets/af85d8f4-5801-4109-a197-5e4cc9f4f447" />
<img width="831" height="888" alt="image" src="https://github.com/user-attachments/assets/0f5c3086-bab1-40a5-a52c-cd1793ac4f53" />

