### PR TITLE
fix nil role/job name/job title for fight-tips/nested job dir folders

### DIFF
--- a/layouts/jobs/bis.html
+++ b/layouts/jobs/bis.html
@@ -1,12 +1,14 @@
 {{ define "main" }}
 
-{{ $role := .Page.Parent.Page.Parent.Params.role }}
+{{ $isParentJob := isset .Page.Parent.Params "job_name" }}
+{{ $job := cond $isParentJob .Page.Parent .Page.Parent.Parent }}
+{{ $role := $job.Parent.Params.role }}
 
 <div class="space-y-16">
   {{ $header := dict
     "role" $role
-    "job" .Parent.Params.job_name
-    "jobTitle" .Parent.Title
+    "job" $job.Params.job_name
+    "jobTitle" $job.Title
     "title" .Title
     "icon" "/theme-assets/armoury.svg"
     "lastmod" .Params.lastmod

--- a/layouts/jobs/changes.html
+++ b/layouts/jobs/changes.html
@@ -1,12 +1,14 @@
 {{ define "main" }}
 
-{{ $role := .Page.Parent.Page.Parent.Params.role }}
+{{ $isParentJob := isset .Page.Parent.Params "job_name" }}
+{{ $job := cond $isParentJob .Page.Parent .Page.Parent.Parent }}
+{{ $role := $job.Parent.Params.role }}
 
 <div class="space-y-16">
   {{ $header := dict
     "role" $role
-    "job" .Parent.Params.job_name
-    "jobTitle" .Parent.Title
+    "job" $job.Params.job_name
+    "jobTitle" $job.Title
     "title" .Title
     "icon" "/theme-assets/news.svg"
     "lastmod" .Params.lastmod

--- a/layouts/jobs/qna.html
+++ b/layouts/jobs/qna.html
@@ -1,12 +1,14 @@
 {{ define "main" }}
 
-{{ $role := .Page.Parent.Page.Parent.Params.role }}
+{{ $isParentJob := isset .Page.Parent.Params "job_name" }}
+{{ $job := cond $isParentJob .Page.Parent .Page.Parent.Parent }}
+{{ $role := $job.Parent.Params.role }}
 
 <div class="space-y-16">
   {{ $header := dict
     "role" $role
-    "job" .Parent.Params.job_name
-    "jobTitle" .Parent.Title
+    "job" $job.Params.job_name
+    "jobTitle" $job.Title
     "title" .Title
     "icon" "/theme-assets/question_bubble.svg"
     "lastmod" .Params.lastmod

--- a/layouts/jobs/single.html
+++ b/layouts/jobs/single.html
@@ -1,12 +1,14 @@
 {{ define "main" }}
 
-{{ $role := .Page.Parent.Page.Parent.Params.role }}
+{{ $isParentJob := isset .Page.Parent.Params "job_name" }}
+{{ $job := cond $isParentJob .Page.Parent .Page.Parent.Parent }}
+{{ $role := $job.Parent.Params.role }}
 
 <div class="space-y-16">
   {{ $header := dict
     "role" $role
-    "job" .Parent.Params.job_name
-    "jobTitle" .Parent.Title
+    "job" $job.Params.job_name
+    "jobTitle" $job.Title
     "title" .Title
     "icon" "/theme-assets/book.svg"
     "description" .Params.description


### PR DESCRIPTION
nested folders within a job (e.g. fight-tips) couldn't pull out the job into the header dictionary because it searched for it in "fight tips" instead of the parent folder, which resulted in the fight-tips pages returning null values. this should(? i have very limited hugo knowledge) allow it to search one layer deeper if it can't find anything in the first layer, which allows one subfolder to exist within the job folder itself, that way .mds stored in fight-tips can still return "job name" no matter what.

<img width="760" height="291" alt="image" src="https://github.com/user-attachments/assets/0c509a9b-1cc3-4925-a79c-e18f3129dcb6" />
<img width="343" height="587" alt="image" src="https://github.com/user-attachments/assets/c401ce03-e3c5-41bb-8a98-05bb46429be0" />
<img width="323" height="44" alt="image" src="https://github.com/user-attachments/assets/beb70d96-7d0c-43ac-99fa-58ad0053de81" />


post fix:
<img width="646" height="231" alt="image" src="https://github.com/user-attachments/assets/28b2419e-a539-4efb-827c-b3916d43d82f" />
<img width="1130" height="390" alt="image" src="https://github.com/user-attachments/assets/6b84f0f3-7388-4b8a-bf82-a11f0a434f7e" />
