### PR TITLE
best in slot toc, spacing improvement

### DIFF
--- a/layouts/jobs/bis.html
+++ b/layouts/jobs/bis.html
@@ -18,28 +18,28 @@
   {{ partial "job/single_header.html" $header }}
 
   <div class="responsive-container">
-    <div class="job-guides-container">
-      <div class="markdown max-w-none">
-        {{ range $index, $bis := .Params.bis }}
+    <div class="md:grid grid-cols-12 items-start gap-8 w-full">
+      <div class="table-of-contents-container max-h-screen overflow-y-auto">
+        {{ partial "components/bis_toc.html" . }}
+      </div>
+      <div class="job-guides-container">
+        <div class="markdown max-w-none">
+          {{ range $index, $bis := .Params.bis }}
           <h2 id="{{ $index }}">{{ $bis.name }}</h2>
           {{ $partialPath := printf "components/embeds/%s.html" $bis.type }}
           {{ if templates.Exists (printf "partials/%s" $partialPath) }}
-            {{ partial $partialPath $bis.link }}
+          {{ partial $partialPath $bis.link }}
           {{ else }}
-            {{/* Fallback to generic link if no template matches.
-                 This shouldn't generally happen.
-            */}}
-            {{ partial "components/embeds/genericlink.html" $bis.link }}
+          {{/* Fallback to generic link if no template matches.
+          This shouldn't generally happen.
+          */}}
+          {{ partial "components/embeds/genericlink.html" $bis.link }}
           {{ end }}
           {{ if $bis.description }}
           {{ $bis.description | markdownify }}
           {{ end }}
-        {{ end }}
-      </div>
-    </div>
-    <div class="md:grid grid-cols-12 items-start gap-8 w-full">
-      <div class="table-of-contents-container max-h-screen overflow-y-auto">
-        {{ partial "components/toc.html" . }}
+          {{ end }}
+        </div>
       </div>
     </div>
   </div>

--- a/layouts/partials/components/bis_toc.html
+++ b/layouts/partials/components/bis_toc.html
@@ -1,0 +1,17 @@
+{{ $tocJs := resources.Get "js/tableOfContents.js" }}
+
+<script type="text/javascript" src="{{ $tocJs.RelPermalink }}" defer></script>
+
+{{ if .Params.bis }}
+<div class="card-title pt-6 pb-5">Table of Contents</div>
+<div class="nested-link font-bold py-2">
+  <nav id="TableOfContents">
+    <ul>
+      {{ range $index, $bis := .Params.bis }}
+        <li><a href="#{{ $index }}">{{ $bis.name }}</a></li>
+      {{ end }}
+    </ul>
+  </nav>
+</div>
+<div>&nbsp;</div>
+{{ end }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -3,7 +3,7 @@
 {{ $filteredList := slice }}
 {{ range $list }}
   {{ $nameUpper := upper .Name }}
-  {{ if (not (strings.Contains $nameUpper "ENCOUNTER")) }}
+  {{ if (and .Name (ne .Name "") (not (strings.Contains $nameUpper "ENCOUNTER"))) }}
     {{ $filteredList = $filteredList | append . }}
   {{ end }}
 {{ end }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,5 +1,12 @@
 {{ $current := . }}
 {{ $list := .Site.Menus.main | append .Site.Menus.header }}
+{{ $filteredList := slice }}
+{{ range $list }}
+  {{ $nameUpper := upper .Name }}
+  {{ if (not (strings.Contains $nameUpper "ENCOUNTER")) }}
+    {{ $filteredList = $filteredList | append . }}
+  {{ end }}
+{{ end }}
 <nav class="fixed w-full lg:relative bg-card-light z-50">
   <div class="responsive-container px-4 lg:px-0">
     <div class="flex justify-between">
@@ -16,7 +23,7 @@
       </div>
       <!-- Navbar items -->
       <div class="hidden lg:flex items-center space-x-3 my-4 right-dropdown">
-        {{ range $list }}
+        {{ range $filteredList }}
           {{ partial "nav_item.html" . }}
         {{ end }}
       </div>
@@ -41,7 +48,7 @@
   <!-- mobile menu -->
   <div class="hidden responsive-container mobile-menu">
     <ul class="">
-      {{ range $list }}
+      {{ range $filteredList }}
         <li class="flex flex-wrap">
           <a
             href="{{ .URL }}"

--- a/layouts/partials/header_home.html
+++ b/layouts/partials/header_home.html
@@ -3,7 +3,7 @@
 {{ $filteredList := slice }}
 {{ range $list }}
   {{ $nameUpper := upper .Name }}
-  {{ if (not (strings.Contains $nameUpper "ENCOUNTER")) }}
+  {{ if (and .Name (ne .Name "") (not (strings.Contains $nameUpper "ENCOUNTER"))) }}
     {{ $filteredList = $filteredList | append . }}
   {{ end }}
 {{ end }}

--- a/layouts/partials/header_home.html
+++ b/layouts/partials/header_home.html
@@ -1,11 +1,18 @@
 {{ $current := . }}
 {{ $list := .Site.Menus.main | append .Site.Menus.header }}
+{{ $filteredList := slice }}
+{{ range $list }}
+  {{ $nameUpper := upper .Name }}
+  {{ if (not (strings.Contains $nameUpper "ENCOUNTER")) }}
+    {{ $filteredList = $filteredList | append . }}
+  {{ end }}
+{{ end }}
   <nav role="navigation" class="fixed lg:absolute top-0 left-0 w-full z-50 bg-card-light lg:bg-transparent">
     <div class="responsive-container">
       <div class="flex justify-center">
         <!-- Navbar items -->
         <div class="hidden lg:flex items-center space-x-3 my-4">
-          {{ range $list }}
+          {{ range $filteredList }}
             {{ partial "nav_item.html" . }}
           {{ end }}
         </div>
@@ -23,7 +30,7 @@
     <!-- mobile menu -->
     <div class="hidden responsive-container mobile-menu">
       <ul class="">
-        {{ range $list }}
+        {{ range $filteredList }}
         <li class="flex flex-wrap">
           <a href="{{ .URL }}"
             class="w-11/12 text-lg block py-3 text-white font-semibold {{ if eq $current.Permalink .URL }}text-link-orange{{ end }}"

--- a/layouts/partials/homepage/join.html
+++ b/layouts/partials/homepage/join.html
@@ -1,6 +1,6 @@
 {{ $discord := $.Site.Params.discord }}
 <a class="block" href="https://{{ $discord }}">
-  <div class="join-community bg-cover bg-center my-24 px-4 pt-12 pb-36 sm:pb-12">
+  <div class="join-community bg-cover bg-center mt-24 px-4 pt-12 pb-36 sm:pb-12">
     <div class="container mx-auto">
       <div class="mx-4 sm:mx-14">
         <h1 class="text-md sm:text-2xl pb-2 uppercase font-bold mb-0">Join the community</h1>


### PR DESCRIPTION
adds in best-in-slot table of contents to improve user ability to navigate sets
<img width="1897" height="847" alt="image" src="https://github.com/user-attachments/assets/0c631f50-53a2-4c08-bb69-5797da975e20" />

removes bottom margin spacing on homepage join bar that was splitting it off of the footer and creating deadspace
<img width="2721" height="1297" alt="image" src="https://github.com/user-attachments/assets/19e68188-c3d9-40c9-a696-bf73904aa427" />

<img width="3433" height="1273" alt="image" src="https://github.com/user-attachments/assets/e33e7efc-dac7-4c2c-a3d8-7832e4620222" />

fixes the removal of the encounter button in the nav bar ( the previous solution used an index.md file to make a blank button in balance-static instead of leaving "encounters", this will actually filter the list to remove encounters until it is needed again )
<img width="376" height="70" alt="image" src="https://github.com/user-attachments/assets/0b9e8390-999e-4807-9a9c-f3094981122d" />
<img width="341" height="65" alt="image" src="https://github.com/user-attachments/assets/c2a60e96-b783-47f6-828f-727f9957155d" />
