### PR TITLE
hide advanced guide conditionally, fix spacing

### DIFF
--- a/layouts/jobs/list.html
+++ b/layouts/jobs/list.html
@@ -10,10 +10,13 @@
   {{ with .Page.GetPage "intermediate-guide" }}
     {{ partial "job/intermediate_guides.html" . }}
   {{ end }}
-  {{ partial "job/advanced_guides.html" . }}
-
-  <div class="py-14 bg-no-repeat bg-cover" style="background-image: url('/theme-assets/jobs/{{ lower $role }}/{{ lower $role }}_resources_background.png');">
-    {{/* {{ partial "job/role_resources.html" .Parent }} */}}
-  </div>
+  {{ with .Page.GetPage "advanced-guide" }}
+    {{ if ge (float .Params.patch) 7.0 }}
+      {{ partial "job/advanced_guides.html" . }}
+    {{ end }}
+  {{ end }}
+  <!-- <div class="py-14 bg-no-repeat bg-cover" style="background-image: url('/theme-assets/jobs/{{ lower $role }}/{{ lower $role }}_resources_background.png');">
+    {{ partial "job/role_resources.html" .Parent }}
+  </div> -->
 </div>
 {{ end }}

--- a/layouts/partials/job/advanced_guides.html
+++ b/layouts/partials/job/advanced_guides.html
@@ -6,7 +6,7 @@
 {{ if or ($advancedGuide) ($fightTips) }}
 <div class="responsive-container">
   <div class="role-header mb-8">Advanced Guides</div>
-  <section class="grid grid-cols-1 md:grid-cols-2 gap-8">
+  <section class="grid grid-cols-1 md:grid-cols-2 gap-8 mb-16">
     <div>
       {{ with $advancedGuide}}
         {{ $content := dict


### PR DESCRIPTION
hides any advanced guide displaying if the patch number is not at least 7.0 or if the advanced_guide.md file is not present, and also fixes a weird element that was included presumably for spacing purposes to avoid having the advanced guide touch the footer when hiding the job_resources page (that was hidden and seemingly never set up.)

<img width="2902" height="946" alt="image" src="https://github.com/user-attachments/assets/bcaad940-5392-476d-a6df-6985b0e575d0" />
<img width="2917" height="700" alt="image" src="https://github.com/user-attachments/assets/6da74d4b-0356-42c2-9d91-da0831f063ab" />
<img width="2911" height="809" alt="image" src="https://github.com/user-attachments/assets/d13b4057-309f-4f9b-8a63-73c118b96325" />
