### PR TITLE
fixes spacing issues, advanced guide/fight tips conditional rendering, replaces newsfeed with discord button

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -16,9 +16,9 @@ theme = "glam"
     url = '/encounters/'
     weight = 20
   [[menu.header]]
-    identifier = 'news'
-    name = 'Newsfeed'
-    url = '/news/'
+    identifier = 'discord'
+    name = 'Discord'
+    url = 'https://discord.gg/thebalanceffxiv'
     weight = 60
   [[menu.footer]]
     identifier = 'info'

--- a/layouts/jobs/list.html
+++ b/layouts/jobs/list.html
@@ -1,6 +1,8 @@
 {{ define "main" }}
 
 {{ $role := .Page.Parent.Params.role }}
+{{ $advancedGuide := .Page.GetPage "advanced-guide" }}
+{{ $fightTips := .Page.GetPage "fight-tips" }}
 
 {{ partial "job/header.html" . }}
 
@@ -10,10 +12,8 @@
   {{ with .Page.GetPage "intermediate-guide" }}
     {{ partial "job/intermediate_guides.html" . }}
   {{ end }}
-  {{ with .Page.GetPage "advanced-guide" }}
-    {{ if ge (float .Params.patch) 7.0 }}
-      {{ partial "job/advanced_guides.html" . }}
-    {{ end }}
+  {{ if or ($advancedGuide) ($fightTips) }}
+    {{ partial "job/advanced_guides.html" . }}
   {{ end }}
   <!-- <div class="py-14 bg-no-repeat bg-cover" style="background-image: url('/theme-assets/jobs/{{ lower $role }}/{{ lower $role }}_resources_background.png');">
     {{ partial "job/role_resources.html" .Parent }}

--- a/layouts/jobs/list.html
+++ b/layouts/jobs/list.html
@@ -1,8 +1,8 @@
 {{ define "main" }}
 
 {{ $role := .Page.Parent.Params.role }}
-{{ $advancedGuide := .Page.GetPage "advanced-guide" }}
-{{ $fightTips := .Page.GetPage "fight-tips" }}
+{{ $advancedGuide := .Page.GetPage "advanced-guide"}}
+{{ $fightTips := .Page.GetPage "fight-tips"}}
 
 {{ partial "job/header.html" . }}
 
@@ -13,7 +13,7 @@
     {{ partial "job/intermediate_guides.html" . }}
   {{ end }}
   {{ if or ($advancedGuide) ($fightTips) }}
-    {{ partial "job/advanced_guides.html" . }}
+      {{ partial "job/advanced_guides.html" . }}
   {{ end }}
   <!-- <div class="py-14 bg-no-repeat bg-cover" style="background-image: url('/theme-assets/jobs/{{ lower $role }}/{{ lower $role }}_resources_background.png');">
     {{ partial "job/role_resources.html" .Parent }}

--- a/layouts/partials/cards/guide.html
+++ b/layouts/partials/cards/guide.html
@@ -1,6 +1,6 @@
 {{ $borderClass := default "gray-600" .role }}
 
-<a href="{{ .inlineLink }}" class="flex flex-col group">
+<a href="{{ .inlineLink }}" class="flex flex-col group h-full justify-end">
   {{ if isset . "image" }}
   <div class="bg-card-dark {{ .imageClass }}">
     {{ with .image }}

--- a/layouts/partials/cards/leveling.html
+++ b/layouts/partials/cards/leveling.html
@@ -1,6 +1,6 @@
 {{ $borderClass := default "gray-600" .role }}
 
-<a href="{{ .inlineLink }}" class="flex flex-col group">
+<a href="{{ .inlineLink }}" class="flex flex-col group h-full justify-end">
   {{ if isset . "image" }}
   <div class="bg-card-dark {{ .imageClass }}">
     {{ with .image }}

--- a/layouts/partials/job/advanced_guides.html
+++ b/layouts/partials/job/advanced_guides.html
@@ -26,8 +26,8 @@
       {{ end }}
     </div>
   {{ end }}
+  {{ if $hasFightTips }}
     <div>
-      {{ if gt (len $fightTips.Pages) 0 }}
         {{ with index $fightTips.Pages 0}}
           {{ $content := dict
               "role" $role
@@ -52,8 +52,8 @@
             }}
             {{ partial "cards/guide.html" $content }}
         {{ end }}
-      {{ end }}
       </div>
+  {{ end }}
   </section>
 </div>
 {{ end }}

--- a/layouts/partials/job/advanced_guides.html
+++ b/layouts/partials/job/advanced_guides.html
@@ -3,27 +3,30 @@
 {{ $advancedGuide := .Page.GetPage "advanced-guide"}}
 {{ $fightTips := .Page.GetPage "fight-tips"}}
 
-{{ if or ($advancedGuide) ($fightTips) }}
+{{ $hasValidAdvancedGuide := and $advancedGuide (ge (float $advancedGuide.Params.patch) 7.0) }}
+{{ $hasFightTips := and $fightTips (gt (len $fightTips.Pages) 0) }}
+
+{{ if or ($hasValidAdvancedGuide) ($hasFightTips) }}
 <div class="responsive-container">
   <div class="role-header mb-8">Advanced Guides</div>
   <section class="grid grid-cols-1 md:grid-cols-2 gap-8 mb-16">
-    <div>
-      {{ with $advancedGuide}}
+    {{ if $hasValidAdvancedGuide }}
+      <div>
         {{ $content := dict
           "role" $role
           "icon" "/theme-assets/advanced_guide.svg"
           "name" "Advanced Guide"
-          "patch" .Params.patch
-          "updated" (time.Format "2 Jan, 2006" .Params.lastmod)
-          "image" .Params.card_header_image
+          "patch" $advancedGuide.Params.patch
+          "updated" (time.Format "2 Jan, 2006" $advancedGuide.Params.lastmod)
+          "image" $advancedGuide.Params.card_header_image
           "imageClass" "h-100"
           "inlineLink" "advanced-guide"
         }}
         {{ partial "cards/guide.html" $content }}
-      {{ end }}
-    </div>
-    <div>
-      {{ if gt (len $fightTips.Pages) 0 }}
+      </div>
+    {{ end }} 
+    {{ if $hasFightTips }}
+      <div>
         {{ with index $fightTips.Pages 0}}
           {{ $content := dict
               "role" $role
@@ -47,9 +50,9 @@
               "inlineLink" .RelPermalink
             }}
             {{ partial "cards/guide.html" $content }}
-        {{ end }}
-      {{ end }}
+          {{ end }}
       </div>
+    {{ end }}
   </section>
 </div>
 {{ end }}

--- a/layouts/partials/job/advanced_guides.html
+++ b/layouts/partials/job/advanced_guides.html
@@ -1,32 +1,33 @@
 {{ $role := .Page.Parent.Params.role }}
 
 {{ $advancedGuide := .Page.GetPage "advanced-guide"}}
+{{ $validAdvancedGuide := and $advancedGuide (ge (float $advancedGuide.Params.patch) 7.0) }}
 {{ $fightTips := .Page.GetPage "fight-tips"}}
-
-{{ $hasValidAdvancedGuide := and $advancedGuide (ge (float $advancedGuide.Params.patch) 7.0) }}
 {{ $hasFightTips := and $fightTips (gt (len $fightTips.Pages) 0) }}
 
-{{ if or ($hasValidAdvancedGuide) ($hasFightTips) }}
+{{ if or ($validAdvancedGuide) ($hasFightTips) }}
 <div class="responsive-container">
   <div class="role-header mb-8">Advanced Guides</div>
   <section class="grid grid-cols-1 md:grid-cols-2 gap-8 mb-16">
-    {{ if $hasValidAdvancedGuide }}
-      <div>
+  {{ if $validAdvancedGuide }}
+    <div>
+      {{ with $advancedGuide}}
         {{ $content := dict
           "role" $role
           "icon" "/theme-assets/advanced_guide.svg"
           "name" "Advanced Guide"
-          "patch" $advancedGuide.Params.patch
-          "updated" (time.Format "2 Jan, 2006" $advancedGuide.Params.lastmod)
-          "image" $advancedGuide.Params.card_header_image
+          "patch" .Params.patch
+          "updated" (time.Format "2 Jan, 2006" .Params.lastmod)
+          "image" .Params.card_header_image
           "imageClass" "h-100"
           "inlineLink" "advanced-guide"
         }}
         {{ partial "cards/guide.html" $content }}
-      </div>
-    {{ end }} 
-    {{ if $hasFightTips }}
-      <div>
+      {{ end }}
+    </div>
+  {{ end }}
+    <div>
+      {{ if gt (len $fightTips.Pages) 0 }}
         {{ with index $fightTips.Pages 0}}
           {{ $content := dict
               "role" $role
@@ -50,9 +51,9 @@
               "inlineLink" .RelPermalink
             }}
             {{ partial "cards/guide.html" $content }}
-          {{ end }}
+        {{ end }}
+      {{ end }}
       </div>
-    {{ end }}
   </section>
 </div>
 {{ end }}

--- a/layouts/partials/job/fundamentals.html
+++ b/layouts/partials/job/fundamentals.html
@@ -12,7 +12,7 @@
         {{ $levelingInfo := dict
           "role" $role
           "image" .Params.card_header_image
-          "imageClass" "h-52"
+          "imageClass" "h-[14.55rem]"
           "icon" "/theme-assets/sprout.svg"
           "name" "Leveling Guide"
           "patch" .Params.patch

--- a/layouts/partials/job/fundamentals.html
+++ b/layouts/partials/job/fundamentals.html
@@ -19,7 +19,7 @@
           "updated" (time.Format "2 Jan, 2006" .Params.lastmod)
           "inlineLink" "leveling-guide"
         }}
-        {{ partial "cards/guide.html" $levelingInfo }}
+        {{ partial "cards/leveling.html" $levelingInfo }}
       {{ end }}
     </div>
 

--- a/layouts/partials/job/intermediate_guides.html
+++ b/layouts/partials/job/intermediate_guides.html
@@ -5,7 +5,7 @@
 
 {{ with $intermediateGuide}}<div class="responsive-container">
     <div class="role-header mb-8">intermediate Guides</div>
-    <section class="grid grid-cols-1 md:grid-cols-2 gap-8">
+    <section class="grid grid-cols-1 md:grid-cols-2 gap-8 mb-16">
     <div>
         {{ $content := dict
           "role" $role

--- a/layouts/partials/nav_item.html
+++ b/layouts/partials/nav_item.html
@@ -1,6 +1,6 @@
 <ul class="nav-item">
   <li class="block transition-all duration-75 relative">
-    <a href="{{ .URL | urlize }}"
+    <a href="{{ .URL }}"
        class="py-2 px-4 font-semibold text-xl text-white hover:text-link-orange border-b-2 border-link-orange border-opacity-0 hover:border-opacity-100"
        title="{{ .Title }}">
       {{ .Name }}


### PR DESCRIPTION
<img width="308" height="81" alt="Screenshot 2025-09-09 161022" src="https://github.com/user-attachments/assets/99415e9d-52c2-4e87-814c-dbd032ff71c0" />
<img width="1772" height="692" alt="Screenshot 2025-09-09 160840" src="https://github.com/user-attachments/assets/18527b28-b83b-4f1e-a551-29b05704f372" />
<img width="1777" height="673" alt="Screenshot 2025-09-09 161007" src="https://github.com/user-attachments/assets/f0845a16-89ba-4797-b039-4923d838efb0" />
<img width="1611" height="823" alt="image" src="https://github.com/user-attachments/assets/59adcb06-222e-48f4-adb9-a423fa928d37" />
<img width="1208" height="1080" alt="image" src="https://github.com/user-attachments/assets/6e34646d-0ba7-422f-aabb-dd023022a669" />
<img width="1776" height="777" alt="image" src="https://github.com/user-attachments/assets/5f6da4cd-996b-4b4d-b4e1-5a31f72dc80b" />
<img width="1935" height="1220" alt="image" src="https://github.com/user-attachments/assets/d31fa941-4ff7-4ab5-9dbd-c128ef363a1d" />

makes it so that the fight tips pages can generate independently from the advanced guide and with proper spacing, fixes the weird gap that was putting the levelling card over the guides cards to the right, and changes newsfeed to discord

the images are blank because i didn't download/copy prod images onto my pc, but they work fine