### PR TITLE
improvements to header styling/resizing

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -539,14 +539,23 @@ Footer
 }
 
 .job-icon-header {
-  width: 60px;
-  height: 60px;
+  width: 35px;
+  height: 35px;
 }
 
 @screen md {
   .job-icon-header {
+    width: 45px;
+    height: 45px;
+  }
+}
+
+@screen xl {
+  .job-icon-header {
     width: 100%;
     height: 100%;
+    max-width: 60px;
+    max-height: 60px;
   }
 }
 

--- a/layouts/partials/job/header.html
+++ b/layouts/partials/job/header.html
@@ -4,10 +4,10 @@
 <div class="h-36 xl:h-80">
   <div class="responsive-container z-10 relative flex items-center h-full">
     <div class="flex items-center md:items-center flex-row w-full mt-0 md:mt-16 md:mb-12 lg:mb-0 lg:mt-0">
-      <div class="w-1/12 xl:w-32 md:h-20 xl:h-32">
-        <img class="job-icon-header mr-2 xl:mr-8 filter drop-shadow-lg-{{ $role }}" src="/theme-assets/jobs/{{ (lower $role) }}/{{ (lower $job) }}/{{ (lower $job) }}.svg" />
+      <div>
+        <img class="job-icon-header mr-4 xl:mr-8 filter drop-shadow-lg-{{ $role }}" src="/theme-assets/jobs/{{ (lower $role) }}/{{ (lower $job) }}/{{ (lower $job) }}.svg" />
       </div>
-      <h1 class="text-3xl md:text-4xl xl:text-6xl font-semibold filter ml-8 drop-shadow-lg-{{ $role }} mb-0">{{ .Title }}</h1>
+      <h1 class="text-4xl md:text-5xl xl:text-6xl font-semibold filter drop-shadow-lg-{{ $role }} mb-0">{{ .Title }}</h1>
     </div>
   </div>
   <div 

--- a/layouts/partials/job/single_header.html
+++ b/layouts/partials/job/single_header.html
@@ -1,19 +1,19 @@
 <div class="h-112 lg:h-96 xl:h-80 bg-no-repeat bg-cover" style='background-image: url(/theme-assets/jobs/{{ lower .role }}/{{ .job }}/{{ .job }}_background.png);'>
   <div class="responsive-container z-10 relative flex items-center h-full mt-4 lg:mt-0">
     <div class="grid grid-cols-12 lg:gap-8 w-full items-center mt-8 lg:mt-0">
-        <div class="col-span-12 lg:col-span-9 text-white responsive-container">
-          <div class="flex items-center mb-7">
+        <div class="col-span-12 lg:col-span-9 text-white responsive-container h-full flex flex-wrap content-evenly">
+          <div class="flex items-center mb-7 w-full">
             <a href="{{ .pageContext.Parent.Permalink }}" class="flex flex-row items-center" >
               <img class="job-icon-sm mr-4 filter drop-shadow-lg-{{ .role }}" src='{{ print "/theme-assets/jobs/" (lower .role) "/" (lower .job) "/" (lower .job) ".svg" }}' />
-              <div class="card-title filter drop-shadow-lg-{{ .role }}">{{ .jobTitle }}</div> 
+              <div class="!text-3xl card-title filter drop-shadow-lg-{{ .role }}">{{ .jobTitle }}</div> 
             </a>
           </div>
           <div>
             <div class="flex items-center mb-4">
               {{ with .icon }}
-                <img class="inline mr-8 filter drop-shadow-lg-{{ $.role }}" src="{{ . }}" />
+                <img class="job-icon-header inline mr-8 filter drop-shadow-lg-{{ $.role }}" src="{{ . }}" />
               {{ end }}
-              <div class="font-bold filter drop-shadow-lg-{{ .role }} text-2xl lg:text-6xl">{{ .title }}</div>
+              <div class="font-bold filter drop-shadow-lg-{{ .role }} text-4xl md:text-5xl xl:text-6xl md:text-nowrap">{{ .title }}</div>
             </div>
             {{ with .description }}
               <div class="filter drop-shadow-lg-{{ $.role }} mb-4">{{ . }}</div>


### PR DESCRIPTION
the header currently has a weird spacing solution that causes the icon to be extraordinarily large on desktop and not resize appropriately, creating odd effects on mobile and narrower widths as well

this keeps the icon and text size uniform at what i felt was a nice looking size, and attempts to do the same for guide pages, granting more space between job name and page title, since they were quite cramped and not using the room they have in the div
job landing page:
<img width="1869" height="540" alt="image" src="https://github.com/user-attachments/assets/dbd63411-82c2-4a75-85a3-c2392406f96e" />
<img width="1806" height="640" alt="image" src="https://github.com/user-attachments/assets/57617eae-d3be-4d64-8551-1b6465103552" />

narrow:
<img width="699" height="642" alt="image" src="https://github.com/user-attachments/assets/91e41f6c-da0c-4213-8fc2-e25d99861df0" />
<img width="702" height="650" alt="image" src="https://github.com/user-attachments/assets/629fef65-8ecd-4b2a-aedc-011b68733952" />

guide page:
<img width="1785" height="576" alt="image" src="https://github.com/user-attachments/assets/46f89c01-6964-4199-b9c9-e3c1d2c032d9" />
<img width="1769" height="558" alt="image" src="https://github.com/user-attachments/assets/7614dafb-a6ce-4fa4-ba9c-6dce240cd109" />

narrow:
<img width="699" height="614" alt="image" src="https://github.com/user-attachments/assets/f4e5d566-f1fe-474e-ad4d-cf7b45bfd6b9" />
<img width="695" height="626" alt="image" src="https://github.com/user-attachments/assets/eafa428c-70d5-4a6a-a57d-ff083785662e" />

