### PR TITLE
register CMS templates for fight-tips

### DIFF
--- a/layouts/editor/baseof.html
+++ b/layouts/editor/baseof.html
@@ -70,6 +70,19 @@
       CMS.registerPreviewTemplate("faq", faqTemplate);
       CMS.registerPreviewTemplate("stat-priority", statPriorityTemplate);
       CMS.registerPreviewTemplate("job-changes", changesTemplate);
+      
+      // append every job into an array and create a template for each of them
+      const jobs = [
+        "pld", "war", "drk", "gnb", // tanks
+        "whm", "sch", "ast", "sge", // healers
+        "mnk", "drg", "nin", "sam", "rpr", "vpr", // melee
+        "brd", "mch", "dnc", // ranged
+        "blm", "smn", "rdm", "pct" // casters
+      ];
+
+      jobs.forEach(job => {
+        CMS.registerPreviewTemplate(`${job}-fight-tips`, GenericJobGuide);
+      });
     </script>
   </body>
 </html>


### PR DESCRIPTION
fight-tips did not have a working page preview, and since each link is unique, it has to be fed the job through an array to register each section as an individual template, but maybe this can be reworked in the future if the structure of config.yml and the fight-tips path is ever reworked