### PR TITLE
better rescaling implementation for mobile

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -5,11 +5,6 @@
 /*
 * Global
  */
-@media (max-width: 640px) {
-  body {
-    zoom: 0.8;
-  }
-}
 
 body {
   @apply font-sans text-white;
@@ -17,6 +12,12 @@ body {
   display: flex;
   flex-direction: column;
   min-height: 100vh;
+}
+
+@media (max-width: 639px) {
+  html {
+    font-size: 13px;
+  }
 }
 
 html {

--- a/assets/js/tableOfContents.js
+++ b/assets/js/tableOfContents.js
@@ -246,9 +246,8 @@ function detectMobileRestyle() {
   
   window.addEventListener('resize', onResize, { passive: true })
 
-  // first check on load and after a small delay to ensure proper rendering
+  // first check on load
   restyleCheck()
-  setTimeout(restyleCheck, 100)
 }
 
 // starts the restyle detection after DOM is loaded


### PR DESCRIPTION
uses rem modification to scale the page to 80% on mobile screens instead of css: zoom property, the zoom property seems like its still too new for mobile browsers to work properly.