### PR TITLE
fix redirect error

### DIFF
--- a/exampleSite/content/jobs/_index.md
+++ b/exampleSite/content/jobs/_index.md
@@ -3,4 +3,5 @@ title: Jobs
 type: redirect
 redirect_to: /
 redirect_after: 3 # (Optional) Seconds to wait before performing the redirect. Default: 0
+outputs: [HTML]
 ---


### PR DESCRIPTION
the config.toml differences between the live site and example site result in the live site serving the rss feed instead of the html redirect page