### PR TITLE
homepage styling improvements

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -16,7 +16,7 @@
     {{ else }}
       {{- partial "header.html" . -}}
     {{ end }}
-    <div id="content" class="z-20">
+    <div id="content" class="z-20{{ if eq $title "Home" }} flex flex-wrap justify-center{{ end }}">
       {{- block "main" . }}{{- end }}
     </div>
     {{- partial "footer.html" . -}}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-<div class="responsive-container">
+<div class="responsive-container mt-20 mb-4 sm:my-6 lg:my-12">
   {{ partial "homepage/role_slider.html" . }}
   {{/*  {{ partial "homepage/recents.html" . }}  */}}
 </div>

--- a/layouts/partials/homepage/join.html
+++ b/layouts/partials/homepage/join.html
@@ -1,6 +1,6 @@
 {{ $discord := $.Site.Params.discord }}
-<a class="block" href="https://{{ $discord }}">
-  <div class="join-community bg-cover bg-center mt-24 px-4 pt-12 pb-36 sm:pb-12">
+<a class="block w-full" href="https://{{ $discord }}">
+  <div class="join-community bg-cover bg-center px-4 pt-12 pb-36 sm:pb-12">
     <div class="container mx-auto">
       <div class="mx-4 sm:mx-14">
         <h1 class="text-md sm:text-2xl pb-2 uppercase font-bold mb-0">Join the community</h1>


### PR DESCRIPTION
the homepage had some awkward container spacing that i wanted to fix up, so here are some previews of the changes:

primarily it just spaces the primary job container better and centers it up, so that it isn't randomly using less space under the join me banner than it is the top portion with the header banner

old:
<img width="3198" height="986" alt="image" src="https://github.com/user-attachments/assets/da59fe10-fcf1-4654-ab95-e769a25d431a" />

new:
<img width="3199" height="1020" alt="image" src="https://github.com/user-attachments/assets/4691dcc2-7e3c-48f8-ac5c-30b6e51ff1cb" />

old:
<img width="1087" height="1205" alt="image" src="https://github.com/user-attachments/assets/873c07ed-d934-462c-bfdc-da99435eb0f5" />

new:
<img width="1078" height="1243" alt="image" src="https://github.com/user-attachments/assets/4cacae2f-0233-46ef-86d1-28da96703ef6" />

old:
<img width="598" height="1169" alt="image" src="https://github.com/user-attachments/assets/3c2fcda2-e9e2-4a36-ae0d-7cd9e1489694" />

new:
<img width="600" height="1164" alt="image" src="https://github.com/user-attachments/assets/0e90b8f7-a8c0-4742-9a2e-6747c3b52642" />
