### PR TITLE
Fix console warning on external links, add css to editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,3 +15,8 @@ indent_size = 2
 [*.js]
 indent_style = space
 indent_size = 4
+
+# 2 space indentation
+[*.css]
+indent_style = space
+indent_size = 2

--- a/assets/js/externalLinks.js
+++ b/assets/js/externalLinks.js
@@ -1,10 +1,12 @@
-// Don't boost links to external websites
+// Don't preload nor boost links to external websites, e.g. the discord link in the header.
 document.body.addEventListener('htmx:configRequest', e => {
     const url = new URL(e.detail.path, window.location.origin);
-    if (url.origin !== window.location.origin && e.detail.boosted) {
+    if (url.origin !== window.location.origin) {
         // Stop HTMX from processing the event.
         e.preventDefault();   // prevent the htmx request
-        // Perform normal browser navigation instead.
-        window.location.href = e.detail.path;  // fallback to full navigation
+        if (e.detail.boosted) {
+            // Perform normal browser navigation instead.
+            window.location.href = e.detail.path;  // fallback to full navigation
+        }
     }
 });


### PR DESCRIPTION
Fixes the console warning from htmx not being able to cross-origin fetch the discord link.

Also adds 2-spaces for CSS files to editorconfig.