### PR TITLE
fix mathjax loading, triggering it after page load

### DIFF
--- a/layouts/partials/math.html
+++ b/layouts/partials/math.html
@@ -1,4 +1,3 @@
-<script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js"></script>
 <script>
   MathJax = {
     tex: {
@@ -6,4 +5,17 @@
       inlineMath: [['\\(', '\\)']]                  // inline
     }
   };
+
+    function triggerMathJax() {
+    if (window.MathJax && window.MathJax.typesetPromise) {
+      window.MathJax.typesetPromise();
+    }
+  }
+
+  document.addEventListener("DOMContentLoaded", triggerMathJax); // Normal page load
+  document.addEventListener("swup:contentReplaced", triggerMathJax); // Swup engine
+  document.addEventListener("turbolinks:load", triggerMathJax); // Turbolinks engine
+  document.addEventListener("turbo:load", triggerMathJax); // Turbo engine
+  document.addEventListener("htmx:afterSwap", triggerMathJax); // HTMX framework
 </script>
+<script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@4/tex-mml-chtml.js"></script>


### PR DESCRIPTION
fixes mathjax loading to retrigger after page load, which lets stuff load asynchronously/optimally but means the latex renders properly

background: the latex rendering seemed to somehow become buggy and require a reload to work, reproduced it locally and this seems to fix it